### PR TITLE
Deprecate MoreCollectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,6 @@ working with streams of Map entries readable. [MoreCollectors](#morecollectors) 
 [![CircleCI Build Status](https://circleci.com/gh/palantir/streams/tree/master.svg)](https://circleci.com/gh/palantir/streams)
 [![Download](https://api.bintray.com/packages/palantir/releases/streams/images/download.svg) ](https://bintray.com/palantir/releases/streams/_latestVersion)
 
-## MoreCollectors
-
-    import com.palantir.common.streams.MoreCollectors;
-
-MoreCollectors allows one to convert their stream directly into a collection that is immutable, the underlying collection type is not guaranteed.
-
-    Stream.of(1, 2, 3)
-        .map(v -> v * 2)
-        .collect(MoreCollectors.toImmutableList());
-
-The collectors currently provided:
-* toImmutableList()
-* toImmutableSet()
-* toImmutableMap()
-
 
 ## KeyedStream
 

--- a/src/main/java/com/palantir/common/streams/MoreCollectors.java
+++ b/src/main/java/com/palantir/common/streams/MoreCollectors.java
@@ -15,25 +15,28 @@
  */
 package com.palantir.common.streams;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 /**
  * Java 8 {@link Collector} for immutable collections.
  */
 public class MoreCollectors {
 
-    /*
+    /**
      * This collector has similar semantics to {@link Collectors::toSet} except that the resulting set will be
      * immutable.
+     *
+     * @deprecated Use {@link ImmutableSet#toImmutableSet}, available in Guava 21+
      */
+    @Deprecated
     public static <T> Collector<T, ?, Set<T>> toImmutableSet() {
         return Collector.of(
                 ImmutableSet::<T>builder,
@@ -43,10 +46,13 @@ public class MoreCollectors {
                 Collector.Characteristics.UNORDERED);
     }
 
-    /*
+    /**
      * This collector has similar semantics to {@link Collectors::toList} except that the resulting list will be
      * immutable.
+     *
+     * @deprecated Use {@link ImmutableList#toImmutableList}, available in Guava 21+
      */
+    @Deprecated
     public static <T> Collector<T, ?, List<T>> toImmutableList() {
         return Collector.of(
                 ImmutableList::<T>builder,
@@ -55,10 +61,13 @@ public class MoreCollectors {
                 ImmutableList.Builder::build);
     }
 
-    /*
+    /**
      * This collector has similar semantics to {@link Collectors::toMap} except that the resulting map will be
      * immutable. Duplicate keys will result in an error.
+     *
+     * @deprecated Use {@link ImmutableMap#toImmutableMap}, available in Guava 21+
      */
+    @Deprecated
     public static <T, K, V> Collector<T, ?, Map<K, V>> toImmutableMap(Function<T, K> keyFunction,
                                                                       Function<T, V> valueFunction) {
         return Collector.of(


### PR DESCRIPTION
Equivalent methods with more efficient implementations are available in Guava 21+.