### PR TITLE
Expose collect methods to immutable types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,7 @@ group 'com.palantir.common'
 version System.env.CIRCLE_TAG ?: gitVersion()
 
 dependencies {
-  // Pull Guava 21 for JavaDocs, but we don't need it at runtime
-  compileOnly 'com.google.guava:guava:21.0'
-  runtime 'com.google.guava:guava:18.0'
+  compile 'com.google.guava:guava:21.0'
   testCompile 'junit:junit:4.12'
   testCompile 'org.assertj:assertj-core:3.5.2'
   testCompile 'org.mockito:mockito-core:2.10.0'

--- a/src/main/java/com/palantir/common/streams/KeyedStream.java
+++ b/src/main/java/com/palantir/common/streams/KeyedStream.java
@@ -17,6 +17,11 @@ package com.palantir.common.streams;
 
 import static com.google.common.collect.Maps.immutableEntry;
 
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Multimaps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -29,6 +34,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.collect.LinkedHashMultimap;
@@ -156,6 +162,18 @@ public interface KeyedStream<K, V> {
     }
 
     /**
+     * Accumulates the entries of this stream using the provided collector.
+     */
+    <A, R> R collect(Collector<Map.Entry<? extends K, ? extends V>, A, R> collector);
+
+    /**
+     * Accumulates the entries of this stream into a new {@code ImmutableMap}.
+     */
+    default ImmutableMap<K, V> collectToImmutableMap() {
+        return collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
      * Accumulates the entries of this stream into a new map.
      *
      * <p>There are no guarantees on the type, mutability, serializability, or thread-safety of the
@@ -188,6 +206,20 @@ public interface KeyedStream<K, V> {
      * {@code Multimap} is created by the provided factory.
      */
     <M extends Multimap<K, V>> M collectToMultimap(Supplier<M> multimapFactory);
+
+    /**
+     * Accumulates the entries of this stream into a new {@code ImmutableMultimap}, in encounter order.
+     */
+    default ImmutableMultimap<K, V> collectToImmutableMultimap() {
+        return collect(ImmutableListMultimap.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Accumulates the entries of this stream into a new {@code ImmutableSetMultimap}, in encounter order.
+     */
+    default ImmutableSetMultimap<K, V> collectToImmutableSetMultimap() {
+        return collect(ImmutableSetMultimap.toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue));
+    }
 
     /**
      * Returns a stream of the keys of each entry of this stream, dropping the associated values.

--- a/src/main/java/com/palantir/common/streams/KeyedStreamImpl.java
+++ b/src/main/java/com/palantir/common/streams/KeyedStreamImpl.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Multimap;
@@ -46,7 +47,12 @@ class KeyedStreamImpl<K, V> implements KeyedStream<K, V> {
 
     @Override
     public <M extends Multimap<K, V>> M collectToMultimap(Supplier<M> supplier) {
-        return entries.collect(supplier::get, KeyedStreamImpl::accumulate, KeyedStreamImpl::combine);
+        return entries.collect(supplier, KeyedStreamImpl::accumulate, KeyedStreamImpl::combine);
+    }
+
+    @Override
+    public <A, R> R collect(Collector<Entry<? extends K, ? extends V>, A, R> collector) {
+        return entries.collect(collector);
     }
 
     @Override

--- a/src/test/java/com/palantir/common/streams/KeyedStreamTests.java
+++ b/src/test/java/com/palantir/common/streams/KeyedStreamTests.java
@@ -19,6 +19,9 @@ import static com.google.common.collect.Maps.immutableEntry;
 import static com.google.common.truth.Truth.assertThat;
 import static com.palantir.common.streams.KeyedStream.toKeyedStream;
 
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.MultimapBuilder;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
@@ -75,9 +79,29 @@ public class KeyedStreamTests {
     }
 
     @Test
+    public void test_collect_multiple_values_as_immutablemap() {
+        ImmutableMap<Integer, Integer> map = Stream.of(6, 8, 12).collect(toKeyedStream()).collectToImmutableMap();
+        assertThat(map).isEqualTo(ImmutableMap.of(6, 6, 8, 8, 12, 12));
+    }
+
+    @Test
     public void test_stream_multiple_values_as_multimap() {
         SetMultimap<Integer, Integer> map = KeyedStream.stream(ImmutableSetMultimap.of(1, 2, 3, 4)).collectToSetMultimap();
         assertThat(map).isEqualTo(ImmutableSetMultimap.of(3, 4, 1, 2));
+    }
+
+    @Test
+    public void test_collect_multiple_values_as_immutablemultimap() {
+        ImmutableMultimap<Integer, Integer> map = KeyedStream.stream(ImmutableListMultimap.of(1, 2, 1, 4, 1, 8))
+                .collectToImmutableMultimap();
+        assertThat(map).isEqualTo(ImmutableListMultimap.of(1, 2, 1, 4, 1, 8));
+    }
+
+    @Test
+    public void test_collect_multiple_values_as_immutablesetmultimap() {
+        ImmutableSetMultimap<Integer, Integer> map = KeyedStream.stream(ImmutableSetMultimap.of(1, 2, 1, 4))
+                .collectToImmutableSetMultimap();
+        assertThat(map).isEqualTo(ImmutableSetMultimap.of(1, 2, 1, 4));
     }
 
     @Test


### PR DESCRIPTION
This PR exposes additional collection methods to the KeyedStream, and bumps the guava dependency to 21.0. 

The primary motivation is to encourage efficient collection to immutable types. Guava's `ImmutableMap#toImmutableMap` collector leverages access to internal builder members for a more efficient combine step - for maps below millions of entries, this leads to faster collection times than the current default `toMap()` implementation (1*). 

The guava bump to 21.0 is necessary for access to the `ImmutableMap#toImmutableMap` method. 

(1*) Heuristics on collection time for maps of 40_000_000 entries, 10_000 entries, 1_000 entries (ran locally on java 1.8):

```
collectToMap - 40_000_000 entries - try1: 20 seconds
collectToImmutableMap - 40_000_000 entries - try1: 36 seconds
collectToMap - 40_000_000 entries - try2: 15 seconds
collectToImmutableMap - 40_000_000 entries - try2: 34 seconds
collectToMap - 40_000_000 entries - try3: 17 seconds
collectToImmutableMap - 40_000_000 entries - try3: 16 seconds
collectToMap - 40_000_000 entries - try4: 10 seconds
collectToImmutableMap - 40_000_000 entries - try4: 16 seconds
collectToMap - 10_000 entries - try1: 63 seconds
collectToImmutableMap - 10_000 entries - try1: 53 seconds
collectToMap - 10_000 entries - try2: 70 seconds
collectToImmutableMap - 10_000 entries - try2: 58 seconds
collectToMap - 1_000 entries - try1: 66 seconds
collectToImmutableMap - 1_000 entries - try1: 54 seconds
collectToMap - 1_000 entries - try2: 59 seconds
collectToImmutableMap - 1_000 entries - try2: 52 seconds
```
testing:
```
@Test
public void time_it() {
    for (int x = 0; x < 4; x++) {
        timeIt("collectToMap - 40_000_000 entries - try" + x, () -> {
            Map<String, String> map = KeyedStream.of(IntStream.range(0, 40_000_000).mapToObj(integer -> "int_" + integer)).collectToMap();
            assertThat(map.isEmpty()).isFalse();
        });
        timeIt("collectToImmutableMap - 40_000_000 entries - try" + x, () -> {
            Map<String, String> map = KeyedStream.of(IntStream.range(0, 40_000_000).mapToObj(integer -> "int_" + integer)).collectToImmutableMap();
            assertThat(map.isEmpty()).isFalse();
        });
    }
    for (int x = 0; x < 2; x++) {
        timeIt("collectToMap - 10_000 entries - try" + x, () -> {
            for (int x = 0; x < 100_000; x++) {
                Map<String, String> map = KeyedStream.of(IntStream.range(0, 10_000).mapToObj(integer -> "int_" + integer)).collectToMap();
                assertThat(map.isEmpty()).isFalse();
            }
        });
        timeIt("collectToImmutableMap - 10_000 entries - try" + x, () -> {
            for (int x = 0; x < 100_000; x++) {
                Map<String, String> map = KeyedStream.of(IntStream.range(0, 10_000).mapToObj(integer -> "int_" + integer)).collectToImmutableMap();
                assertThat(map.isEmpty()).isFalse();
            }
        });
    }
    for (int x = 0; x < 2; x++) {
        timeIt("collectToMap - 1_000 entries - try" + x, () -> {
            for (int x = 0; x < 1_000_000; x++) {
                Map<String, String> map = KeyedStream.of(IntStream.range(0, 1_000).mapToObj(integer -> "int_" + integer)).collectToMap();
                assertThat(map.isEmpty()).isFalse();
            }
        });
        timeIt("collectToImmutableMap - 1_000 entries - try" + x, () -> {
            for (int x = 0; x < 1_000_000; x++) {
                Map<String, String> map = KeyedStream.of(IntStream.range(0, 1_000).mapToObj(integer -> "int_" + integer)).collectToImmutableMap();
                assertThat(map.isEmpty()).isFalse();
            }
        });
    }
}

private void timeIt(String description, Runnable runnable) {
    long nanosStart = System.nanoTime();
    runnable.run();
    long nanosEnd = System.nanoTime();
    System.out.println(description + ": " + ((nanosEnd - nanosStart) / 1_000_000_000L) + " seconds");
}
```