### PR TITLE
Add unmodifiable map collector to keyed stream

### DIFF
--- a/src/main/java/com/palantir/common/streams/KeyedStream.java
+++ b/src/main/java/com/palantir/common/streams/KeyedStream.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.Maps.immutableEntry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -163,6 +164,13 @@ public interface KeyedStream<K, V> {
      */
     default Map<K, V> collectToMap() {
         return collectTo(LinkedHashMap::new);
+    }
+
+    /**
+     * Returns an unmodifiable view of {@link #collectToMap()}.
+     */
+    default Map<K, V> collectToUnmodifiableMap() {
+        return Collections.unmodifiableMap(collectToMap());
     }
 
     /**


### PR DESCRIPTION
Didn't want to introduce Guava dependency only for this so simply I went for wrapping with `Collections.unmodifiableMap` rather than collecting with `ImmutableMap.toImmutableMap`.