### PR TITLE
Fix incorrect maxParallelism handling on MoreStreams utility methods

### DIFF
--- a/changelog/@unreleased/pr-36.v2.yml
+++ b/changelog/@unreleased/pr-36.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Fix incorrect maxParallelism handling on MoreStreams inCompletionOrder and blockingStreamWithParallelism utility methods. Previously it was possible to fan out far beyond the provided limit, depending on the structure of the stream internals.
+    The MoreStreams inCompletionOrder and blockingStreamWithParallelism overloads without an `Executor` argument have been deprecated, they cannot be fixed due to incorrect assumptions about Streams.
+  links:
+  - https://github.com/palantir/streams/pull/36

--- a/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
@@ -37,7 +37,11 @@ public final class MoreStreams {
     /**
      * Given a stream of listenable futures, this function will return a blocking stream of the completed
      * futures in completion order, looking at most {@code maxParallelism} futures ahead in the stream.
+     *
+     * @deprecated This function provides no guarantees, maxParallelism is
+     * ignored in many cases (e.g. flatmap has been called).
      */
+    @Deprecated
     public static <T, F extends ListenableFuture<T>> Stream<F> inCompletionOrder(
             Stream<F> futures, int maxParallelism) {
         return StreamSupport.stream(
@@ -65,7 +69,11 @@ public final class MoreStreams {
     /**
      * This function will return a blocking stream that waits for each future to complete before returning it,
      * but which looks ahead {@code maxParallelism} futures to ensure a fixed parallelism rate.
+     *
+     * @deprecated This function provides no guarantees, maxParallelism is
+     * ignored in many cases (e.g. flatmap has been called).
      */
+    @Deprecated
     public static <T, F extends ListenableFuture<T>> Stream<F> blockingStreamWithParallelism(
             Stream<F> futures, int maxParallelism) {
         return StreamSupport.stream(


### PR DESCRIPTION
Streams aren't iterators, there's no guarantee that one probe
results in one result.