### PR TITLE
Add MoreCollectors.to*WithExpectedSize helpers

### DIFF
--- a/changelog/@unreleased/pr-173.v2.yml
+++ b/changelog/@unreleased/pr-173.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add MoreCollectors.to*WithExpectedSize helpers
+  links:
+  - https://github.com/palantir/streams/pull/173

--- a/streams/src/test/java/com/palantir/common/streams/MoreCollectorsTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreCollectorsTests.java
@@ -18,7 +18,12 @@ package com.palantir.common.streams;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,59 +34,123 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("RedundantStreamOptionalCall") // explicitly testing map stream
 public class MoreCollectorsTests {
 
-    private static final List<Integer> LARGE_LIST =
-            IntStream.range(0, 100000).boxed().collect(Collectors.toList());
-
-    @Test
-    public void test_immutable_list() {
-        List<Integer> list = LARGE_LIST.stream().collect(MoreCollectors.toImmutableList());
-        assertThat(list).containsExactlyElementsOf(LARGE_LIST);
+    public static Stream<List<Integer>> inputs() {
+        return IntStream.of(0, 1, 1_000, 100_000)
+                .mapToObj(size -> IntStream.range(0, size).boxed().collect(Collectors.toUnmodifiableList()));
     }
 
-    @Test
+    private static final Function<Integer, Integer> triple = x -> x * 3;
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    @SuppressWarnings("deprecation") // explicitly testing
+    public void test_immutable_list(List<Integer> input) {
+        List<Integer> list = input.stream().map(x -> x).collect(MoreCollectors.toImmutableList());
+        assertThat(list).hasSize(input.size()).isEqualTo(input).containsExactlyElementsOf(input);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    @SuppressWarnings({"DangerousParallelStreamUsage", "deprecation"}) // explicitly testing parallel streams
+    public void test_parallel_immutable_list(List<Integer> input) {
+        List<Integer> list = input.parallelStream().collect(MoreCollectors.toImmutableList());
+        assertThat(list)
+                .hasSize(input.size())
+                .isEqualTo(input)
+                .containsExactlyElementsOf(input)
+                .isInstanceOf(ImmutableList.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    @SuppressWarnings("deprecation") // explicitly testing
+    public void test_immutable_set(List<Integer> input) {
+        Set<Integer> set = input.stream().map(x -> x).collect(MoreCollectors.toImmutableSet());
+        assertThat(set).hasSize(input.size()).containsExactlyElementsOf(input).isInstanceOf(ImmutableSet.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    @SuppressWarnings({"DangerousParallelStreamUsage", "deprecation"}) // explicitly testing parallel streams
+    public void test_parallel_immutable_set(List<Integer> input) {
+        Set<Integer> set = input.parallelStream().collect(MoreCollectors.toImmutableSet());
+        assertThat(set).hasSize(input.size()).containsExactlyElementsOf(input).isInstanceOf(ImmutableSet.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    public void test_set_with_expected_size(List<Integer> input) {
+        Set<Integer> set = input.stream().map(x -> x).collect(MoreCollectors.toSetWithExpectedSize(input.size()));
+        assertThat(set).hasSize(input.size()).containsExactlyElementsOf(input).isInstanceOf(LinkedHashSet.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    public void test_immutable_set_with_expected_size(List<Integer> input) {
+        ImmutableSet<Integer> set =
+                input.stream().map(x -> x).collect(MoreCollectors.toImmutableSetWithExpectedSize(input.size()));
+        assertThat(set).hasSize(input.size()).containsExactlyElementsOf(input).isInstanceOf(ImmutableSet.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
     @SuppressWarnings("DangerousParallelStreamUsage") // explicitly testing parallel streams
-    public void test_parallel_immutable_list() {
-        List<Integer> list = LARGE_LIST.parallelStream().collect(MoreCollectors.toImmutableList());
-        assertThat(list).containsExactlyElementsOf(LARGE_LIST);
+    public void test_parallel_immutable_set_with_expected_size(List<Integer> input) {
+        ImmutableSet<Integer> set =
+                input.parallelStream().collect(MoreCollectors.toImmutableSetWithExpectedSize(input.size()));
+        assertThat(set).hasSize(input.size()).containsExactlyElementsOf(input).isInstanceOf(ImmutableSet.class);
     }
-
-    @Test
-    public void test_immutable_set() {
-        Set<Integer> set = LARGE_LIST.stream().collect(MoreCollectors.toImmutableSet());
-        assertThat(set).containsExactlyElementsOf(LARGE_LIST);
-    }
-
-    @Test
-    @SuppressWarnings("DangerousParallelStreamUsage") // explicitly testing parallel streams
-    public void test_parallel_immutable_set() {
-        Set<Integer> set = LARGE_LIST.parallelStream().collect(MoreCollectors.toImmutableSet());
-        assertThat(set).containsExactlyElementsOf(LARGE_LIST);
-    }
-
-    private Function<Integer, Integer> valueMap = x -> x * 2;
 
     @Nested
     class ToImmutableMapDeprecated {
-        @Test
-        public void test_immutable_map() {
-            Map<Integer, Integer> map = LARGE_LIST.stream().collect(MoreCollectors.toImmutableMap(k -> k, valueMap));
-            assertThat(map.keySet()).containsExactlyElementsOf(LARGE_LIST);
-            map.forEach((k, _v) -> assertThat(map.get(k)).isEqualTo(valueMap.apply(k)));
-        }
 
-        @Test
-        @SuppressWarnings("DangerousParallelStreamUsage") // explicitly testing parallel streams
-        public void test_parallel_immutable_map() {
+        @ParameterizedTest
+        @MethodSource("com.palantir.common.streams.MoreCollectorsTests#inputs")
+        @SuppressWarnings("deprecation") // explicitly testing
+        public void test_immutable_map(List<Integer> input) {
             Map<Integer, Integer> map =
-                    LARGE_LIST.parallelStream().collect(MoreCollectors.toImmutableMap(k -> k, valueMap));
-            assertThat(map.keySet()).containsExactlyElementsOf(LARGE_LIST);
-            map.forEach((k, _v) -> assertThat(map.get(k)).isEqualTo(valueMap.apply(k)));
+                    input.stream().map(x -> x).collect(MoreCollectors.toImmutableMap(k -> k, triple));
+            assertThat(map).hasSize(input.size()).containsOnlyKeys(input).isInstanceOf(ImmutableMap.class);
+            map.keySet().forEach(k -> assertThat(map.get(k)).as("key '%s'", k).isEqualTo(triple.apply(k)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.palantir.common.streams.MoreCollectorsTests#inputs")
+        @SuppressWarnings({"DangerousParallelStreamUsage", "deprecation"}) // explicitly testing parallel streams
+        public void test_parallel_immutable_map(List<Integer> input) {
+            Map<Integer, Integer> map = input.parallelStream().collect(MoreCollectors.toImmutableMap(k -> k, triple));
+            assertThat(map).hasSize(input.size()).containsOnlyKeys(input).isInstanceOf(ImmutableMap.class);
+            map.keySet().forEach(k -> assertThat(map.get(k)).as("key '%s'", k).isEqualTo(triple.apply(k)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.palantir.common.streams.MoreCollectorsTests#inputs")
+        @SuppressWarnings("deprecation") // explicitly testing
+        public void test_immutable_map_with_expected_size(List<Integer> input) {
+            Map<Integer, Integer> map =
+                    input.stream().map(x -> x).collect(MoreCollectors.toImmutableMap(k -> k, triple));
+            assertThat(map).hasSize(input.size()).containsOnlyKeys(input).isInstanceOf(ImmutableMap.class);
+            map.keySet().forEach(k -> assertThat(map.get(k)).as("key '%s'", k).isEqualTo(triple.apply(k)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.palantir.common.streams.MoreCollectorsTests#inputs")
+        @SuppressWarnings("DangerousParallelStreamUsage") // explicitly testing parallel streams
+        public void test_parallel_immutable_map_with_expected_size(List<Integer> input) {
+            ImmutableMap<Integer, Integer> map = input.parallelStream()
+                    .collect(MoreCollectors.toImmutableMapWithExpectedSize(input.size(), k -> k, triple));
+            assertThat(map).hasSize(input.size()).containsOnlyKeys(input).isInstanceOf(ImmutableMap.class);
+            map.keySet().forEach(k -> assertThat(map.get(k)).as("key '%s'", k).isEqualTo(triple.apply(k)));
         }
 
         @Test
+        @SuppressWarnings("deprecation") // explicitly testing
         public void test_immutable_map_duplicate_keys() {
             Stream<Integer> stream = Stream.of(1, 1);
             assertThatThrownBy(() -> stream.collect(MoreCollectors.toImmutableMap(k -> k, _k -> 2)))
@@ -90,16 +159,23 @@ public class MoreCollectorsTests {
         }
     }
 
+    private final Function<Integer, Integer> doubleValue = x -> x * 2;
+
     @Nested
     class ToImmutableMap {
 
-        @Test
-        void toImmutableMap_preserves_iteration_order() {
-            Map<Integer, Integer> map = LARGE_LIST.stream()
-                    .map(i -> Maps.immutableEntry(i, valueMap.apply(i)))
+        @ParameterizedTest
+        @MethodSource("com.palantir.common.streams.MoreCollectorsTests#inputs")
+        void toImmutableMap_preserves_iteration_order(List<Integer> input) {
+            ImmutableMap<Integer, Integer> map = input.stream()
+                    .map(i -> Maps.immutableEntry(i, doubleValue.apply(i)))
                     .collect(MoreCollectors.toImmutableMap());
-            assertThat(map.keySet()).containsExactlyElementsOf(LARGE_LIST);
-            map.forEach((k, _v) -> assertThat(map.get(k)).isEqualTo(valueMap.apply(k)));
+            assertThat(map).hasSize(input.size()).isInstanceOf(ImmutableMap.class);
+            assertThat(map.keySet())
+                    .hasSize(input.size())
+                    .containsExactlyElementsOf(input)
+                    .isInstanceOf(ImmutableSet.class);
+            map.forEach((k, _v) -> assertThat(map.get(k)).isEqualTo(doubleValue.apply(k)));
         }
 
         @Test
@@ -126,5 +202,53 @@ public class MoreCollectorsTests {
                     .isInstanceOf(NullPointerException.class)
                     .hasMessage("null value in entry: 1=null");
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    public void test_list_with_expected_size(List<Integer> input) {
+        List<Integer> list = input.stream().map(x -> x).collect(MoreCollectors.toListWithExpectedSize(input.size()));
+        assertThat(list)
+                .hasSize(input.size())
+                .isEqualTo(input)
+                .containsExactlyElementsOf(input)
+                .isInstanceOf(ArrayList.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    @SuppressWarnings("DangerousParallelStreamUsage") // explicitly testing parallel streams
+    public void test_parallel_list_with_expected_size(List<Integer> input) {
+        List<Integer> list = input.parallelStream().collect(MoreCollectors.toListWithExpectedSize(input.size()));
+        assertThat(list)
+                .hasSize(input.size())
+                .isEqualTo(input)
+                .containsExactlyElementsOf(input)
+                .isInstanceOf(ArrayList.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    public void test_immutable_list_with_expected_size(List<Integer> input) {
+        List<Integer> list =
+                input.stream().map(x -> x).collect(MoreCollectors.toImmutableListWithExpectedSize(input.size()));
+        assertThat(list)
+                .hasSize(input.size())
+                .isEqualTo(input)
+                .containsExactlyElementsOf(input)
+                .isInstanceOf(ImmutableList.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("inputs")
+    @SuppressWarnings("DangerousParallelStreamUsage") // explicitly testing parallel streams
+    public void test_parallel_immutable_list_with_expected_size(List<Integer> input) {
+        List<Integer> list =
+                input.parallelStream().collect(MoreCollectors.toImmutableListWithExpectedSize(input.size()));
+        assertThat(list)
+                .hasSize(input.size())
+                .isEqualTo(input)
+                .containsExactlyElementsOf(input)
+                .isInstanceOf(ImmutableList.class);
     }
 }


### PR DESCRIPTION
## WIP Draft for comments

Some questions came up about providing `Stream` collectors that avoid some of the growth & reallocation overhead of JDK standard collectors such as `Collectors.toList()` and where libraries are targeting JDK 11 so cannot use [`Stream::toList()` added in JDK 16](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/stream/Stream.html#toList()).

This typically only matters in more allocation sensitive code in which case use of Guava 
[`Collections2.transform`](https://guava.dev/releases/31.1-jre/api/docs/com/google/common/collect/Collections2.html#transform(java.util.Collection,com.google.common.base.Function)), [`Lists.transform`](https://guava.dev/releases/31.1-jre/api/docs/com/google/common/collect/Lists.html#transform(java.util.List,com.google.common.base.Function)), [`Maps.transformValues`](https://guava.dev/releases/31.1-jre/api/docs/com/google/common/collect/Maps.html#transformValues(java.util.Map,com.google.common.base.Function)) may be better solutions to avoid the intermediate collection copy; however, there are some cases where one must make a copy (e.g. if the elements being transformed are only valid inside a transaction), so providing these mechanisms may be beneficial.

### Questions:

- Do we want to encourage use of these?
  - If used with `filter`, these likely over-allocate in what one might assume are performance/allocation sensitive paths.
  - For the places these matter, should we be encouraging other non-`Stream` implementation?
- Are these worth the API burden & support?
- Is this the place we'd want to land these?
  - Do we want to use `MoreCollectors` as that conflicts with simple type name for [`com.google.common.collect.MoreCollectors`](https://guava.dev/releases/31.1-jre/api/docs/com/google/common/collect/MoreCollectors.html)?
