### PR TITLE
Propagate stream close

### DIFF
--- a/changelog/@unreleased/pr-308.v2.yml
+++ b/changelog/@unreleased/pr-308.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Propagate stream close
+  links:
+  - https://github.com/palantir/streams/pull/308

--- a/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
@@ -47,9 +47,10 @@ public final class MoreStreams {
     public static <T, F extends ListenableFuture<T>> Stream<F> inCompletionOrder(
             Stream<F> futures, int maxParallelism) {
         return StreamSupport.stream(
-                new BufferingSpliterator<>(
-                        InCompletionOrder.INSTANCE, futures.spliterator(), Function.identity(), maxParallelism),
-                NOT_PARALLEL);
+                        new BufferingSpliterator<>(
+                                InCompletionOrder.INSTANCE, futures.spliterator(), Function.identity(), maxParallelism),
+                        NOT_PARALLEL)
+                .onClose(futures::close);
     }
 
     /**
@@ -70,6 +71,7 @@ public final class MoreStreams {
                                 x -> Futures.transform(Futures.immediateFuture(x), mapper::apply, executor),
                                 maxParallelism),
                         NOT_PARALLEL)
+                .onClose(arguments::close)
                 .map(Futures::getUnchecked);
     }
 
@@ -88,6 +90,7 @@ public final class MoreStreams {
                         new BufferingSpliterator<>(
                                 InSourceOrder.INSTANCE, futures.spliterator(), Function.identity(), maxParallelism),
                         NOT_PARALLEL)
+                .onClose(futures::close)
                 .map(MoreFutures::blockUntilCompletion);
     }
 
@@ -107,6 +110,7 @@ public final class MoreStreams {
                                 x -> Futures.transform(Futures.immediateFuture(x), mapper::apply, executor),
                                 maxParallelism),
                         NOT_PARALLEL)
+                .onClose(arguments::close)
                 .map(MoreFutures::blockUntilCompletion)
                 .map(Futures::getUnchecked);
     }


### PR DESCRIPTION
Several `MoreStreams` methods construct new streams, but do not properly propagate closure of the input stream, which could lead to resource leaks