### PR TITLE
MoreCollectors.toImmutableMap() convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,25 @@ the order in which they complete.
 [ListenableFuture]: https://google.github.io/guava/releases/23.0/api/docs/com/google/common/util/concurrent/ListenableFuture.html
 [Map]: https://docs.oracle.com/javase/8/docs/api/java/util/Map.html
 [Stream]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
+
+## MoreCollectors
+
+### `MoreCollectors.toImmutableMap()`
+
+Collect a Stream of Map.Entry (e.g. a StreamEx EntryStream) into a Guava ImmutableMap, which preserves iteration order.
+
+Beware that using StreamEx's `EntryStream#toImmutableMap()` does NOT preserve iteration order, as it uses a regular HashMap under the hood.
+
+```diff
+ StreamEx.of(items)
+        .mapToEntry(
+                key -> computeValue(key.foo())
+-       .toImmutableMap() // does not preserve iteration order
++       .collect(MoreCollectors.toImmutableMap()); // preserves iteration order
+```
+
+This is equivalent to writing out the slightly more verbose:
+
+```java
+        .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+```

--- a/changelog/@unreleased/pr-328.v2.yml
+++ b/changelog/@unreleased/pr-328.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: MoreCollectors.toImmutableMap() convenience method
+  links:
+  - https://github.com/palantir/streams/pull/328

--- a/streams/src/main/java/com/palantir/common/streams/MoreCollectors.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreCollectors.java
@@ -62,6 +62,18 @@ public final class MoreCollectors {
     }
 
     /**
+     * Collect a Stream of Map.Entry (e.g. a StreamEx EntryStream) into a Guava ImmutableMap, which preserves iteration
+     * order. Duplicate keys will result in an error.
+     *
+     * This is just a convenience method for Guava's built-in {@link ImmutableMap#toImmutableMap}.
+     *
+     * Beware that {@code EntryStream#toImmutableMap()} does NOT preserve iteration order, as it uses a regular HashMap.
+     */
+    public static <K, V> Collector<Map.Entry<K, V>, ?, ImmutableMap<K, V>> toImmutableMap() {
+        return ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    /**
      * This collector has similar semantics to {@link Collectors#toMap} except that the resulting map will be
      * immutable. Duplicate keys will result in an error.
      *

--- a/streams/src/main/java/com/palantir/common/streams/MoreCollectors.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreCollectors.java
@@ -62,10 +62,10 @@ public final class MoreCollectors {
     }
 
     /**
-     * Collect a Stream of Map.Entry (e.g. a StreamEx EntryStream) into a Guava ImmutableMap, which preserves iteration
-     * order. Duplicate keys will result in an error.
+     * Collect a Stream of Map.Entry (e.g. a StreamEx EntryStream) into a Guava {@link ImmutableMap}, which preserves
+     * iteration order. Duplicate keys will result in an error. Throws NullPointerException if any key or value is null.
      *
-     * This is just a convenience method for Guava's built-in {@link ImmutableMap#toImmutableMap}.
+     * For behaviour details, see docs on {@link ImmutableMap#toImmutableMap}.
      *
      * Beware that {@code EntryStream#toImmutableMap()} does NOT preserve iteration order, as it uses a regular HashMap.
      */

--- a/streams/src/test/java/com/palantir/common/streams/MoreCollectorsTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreCollectorsTests.java
@@ -112,5 +112,19 @@ public class MoreCollectorsTests {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("Multiple entries with same key: 1=889 and 1=888");
         }
+
+        @Test
+        void throws_if_keys_are_null() {
+            assertThatThrownBy(() -> Stream.of(Maps.immutableEntry(null, 1)).collect(MoreCollectors.toImmutableMap()))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("null key in entry: null=1");
+        }
+
+        @Test
+        void throws_if_values_are_null() {
+            assertThatThrownBy(() -> Stream.of(Maps.immutableEntry(1, null)).collect(MoreCollectors.toImmutableMap()))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("null value in entry: 1=null");
+        }
     }
 }


### PR DESCRIPTION
I want to make it easy for devs to ALWAYS preserve iteration order when accumulating streams into collections, because having completely deterministic outputs makes it easy to write 'golden master' tests where you check in the test output.

Many users of StreamEx use the `.toMap()` or `.toImmutableMap()` methods, which do not preserve iteration order.

Rather than asking everyone to write the verbose `.collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue))` (a sourcegraph search shows that _some_ people are actually doing this), I'd like to provide a convenience method.