### PR TITLE
Add MoreStream utility methods that accept future suppliers

### DIFF
--- a/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
@@ -145,13 +145,10 @@ public final class MoreStreams {
      * will be made serially.
      */
     public static <U, V, F extends ListenableFuture<V>> Stream<V> blockingStreamWithParallelism(
-            Stream<U> arguments, Function<U, F> mapper,  int maxParallelism) {
+            Stream<U> arguments, Function<U, F> mapper, int maxParallelism) {
         return StreamSupport.stream(
                         new BufferingSpliterator<>(
-                                InSourceOrder.INSTANCE,
-                                arguments.spliterator(),
-                                mapper,
-                                maxParallelism),
+                                InSourceOrder.INSTANCE, arguments.spliterator(), mapper, maxParallelism),
                         NOT_PARALLEL)
                 .onClose(arguments::close)
                 .map(MoreFutures::blockUntilCompletion)

--- a/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;

--- a/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;

--- a/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
@@ -15,7 +15,32 @@
  */
 package com.palantir.common.streams;
 
-import com.google.common.util.concurrent.*;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
+import java.util.Spliterator;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,22 +48,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.time.Duration;
-import java.util.Spliterator;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreStreamsTests.java
@@ -15,28 +15,7 @@
  */
 package com.palantir.common.streams;
 
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
-import java.time.Duration;
-import java.util.Spliterator;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import com.google.common.util.concurrent.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +23,23 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.time.Duration;
+import java.util.Spliterator;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -112,6 +108,24 @@ public class MoreStreamsTests {
     }
 
     @Test
+    public void testInCompletionOrder_transformWithFutureSupplier() throws InterruptedException {
+        ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(3));
+        UnaryOperator<Integer> reorder = reorder();
+        Function<Integer, ListenableFuture<Integer>> futureSupplier =
+                i -> executorService.submit(() -> reorder.apply(i));
+
+        // 2 cannot start until a task has finished, 0 cannot start until 2 is running, so 1 must come first.
+        try (Stream<Integer> integerStream = MoreStreams.inCompletionOrder(
+                IntStream.range(0, 3).boxed().onClose(() -> streamClosed.set(true)), futureSupplier, 2)) {
+            assertThat(integerStream.collect(toList())).startsWith(1).containsExactlyInAnyOrder(0, 1, 2);
+        } finally {
+            executorService.shutdown();
+            executorService.awaitTermination(1, TimeUnit.SECONDS);
+        }
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
     public void testBlockingStreamWithParallelism_transformWithExecutor() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         // due to size of thread pool, 1 must finish before 0, but 0 will return first.
@@ -154,6 +168,43 @@ public class MoreStreamsTests {
                 },
                 executorService,
                 maxParallelism)) {
+            assertThat(inCompletionOrder.collect(toList())).containsExactlyInAnyOrder(0, 1, 2);
+            assertThat(maximum).hasValue(maxParallelism);
+        } finally {
+            executorService.shutdown();
+            executorService.awaitTermination(1, TimeUnit.SECONDS);
+        }
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testConcurrencySimpleStreamAndFutureSupplier() throws InterruptedException {
+        testConcurrencyWithFutureSupplier(IntStream.range(0, 3).boxed());
+    }
+
+    @Test
+    public void testConcurrencyWithFlatmapAndFutureSupplie() throws InterruptedException {
+        testConcurrencyWithFutureSupplier(
+                Stream.of(1).flatMap(_ignored -> IntStream.range(0, 3).boxed()));
+    }
+
+    private void testConcurrencyWithFutureSupplier(Stream<Integer> value) throws InterruptedException {
+        AtomicInteger maximum = new AtomicInteger(-1);
+        AtomicInteger current = new AtomicInteger();
+        int maxParallelism = 1;
+        ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(3));
+        Function<Integer, ListenableFuture<Integer>> toFuture = input -> executorService.submit(() -> {
+            int running = current.incrementAndGet();
+            maximum.accumulateAndGet(running, Math::max);
+            try {
+                Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(200));
+            } finally {
+                current.decrementAndGet();
+            }
+            return input;
+        });
+        try (Stream<Integer> inCompletionOrder =
+                MoreStreams.inCompletionOrder(value.onClose(() -> streamClosed.set(true)), toFuture, maxParallelism)) {
             assertThat(inCompletionOrder.collect(toList())).containsExactlyInAnyOrder(0, 1, 2);
             assertThat(maximum).hasValue(maxParallelism);
         } finally {


### PR DESCRIPTION
Currently the non-deprecated versions of `inCompletionOrder` and `blockingStreamWithParallelism` require a an executor to run each transformation on, which means that that transformation will be a blocking call. This is not ideal when the actual call is itself async (i.e. hitting a method which returns a `ListenableFuture` already). This PR adds versions of those methods that require a future supplier, that is a method that transforms the keys into the listenable futures of the result. This method will be called by the thread that is pulling from the Stream.

This is similar to earlier problematic methods that accepted an input a stream of futures. Those were deprecated because they did not enforce actual max parallelism. That is, the underlying stream supplier may kick off more futures than the parallelism intended to allow. I believe this solution avoids those issues because we only create new futures from within the buffering spliterator, which enforces the max parallelism.