### PR TITLE
Add MoreIterables.partition

### DIFF
--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     api 'com.google.guava:guava'
 
     implementation 'com.google.errorprone:error_prone_annotations'
+    implementation 'org.jspecify:jspecify'
 
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -59,8 +59,7 @@ public final class MoreIterables {
                 return Lists.partition(immutableCollection.asList(), size);
             }
             if (collection instanceof List<T> list) {
-                return Lists.transform(
-                        Lists.partition(Collections.unmodifiableList(list), size), Collections::unmodifiableList);
+                return Lists.transform(Lists.partition(list, size), Collections::unmodifiableList);
             }
             if (collection.size() <= size) {
                 // Iterables.partition pre-allocates array of `size` waste when `items.size()` does not need partitioned

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -1,0 +1,70 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.streams;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public final class MoreIterables {
+    private MoreIterables() {}
+
+    /**
+     * Divides an iterable into unmodifiable sublists of the given size (the final iterable may be
+     * smaller). For example, partitioning an iterable containing {@code [a, b, c, d, e]} with a
+     * partition size of 3 yields {@code [[a, b, c], [d, e]]} -- an outer iterable containing two
+     * inner lists of three and two elements, all in the original order.
+     * <p>
+     * Iterators returned by the returned iterable do not support the {@link java.util.Iterator#remove()}
+     * method. The returned lists implement {@link java.util.RandomAccess}, if the input list does.
+     * <p>
+     * Similar to Guava {@link com.google.common.collect.Iterables#partition(Iterable, int)} and
+     * {@link com.google.common.collect.Lists#partition(List, int)};
+     * however, {@link Iterables#partition(Iterable, int)} eagerly allocates storage while this implementation
+     * avoids excess allocations and delegates to {@link Lists#partition(List, int)} where possible.
+     *
+     * @param items the collection to return a partitioned view of
+     * @param size the desired size of each sublist (the last may be smaller)
+     * @return an iterable of unmodifiable lists containing the elements of {@code iterable} divided into partitions
+     */
+    public static <T extends @Nullable Object> Iterable<? extends List<T>> partition(Iterable<T> items, int size) {
+        if (items instanceof Collection<T> collection) {
+            // use Lists.partition if possible, which will return sublist without allocating entire
+            // array of partition size.
+            if (collection.isEmpty()) {
+                return ImmutableList.of();
+            }
+            if (collection instanceof ImmutableCollection<T> immutableCollection) {
+                // immutable collections have an internal list that can be partitioned without allocating sublists
+                return Lists.partition(immutableCollection.asList(), size);
+            }
+            if (collection instanceof List<T> list) {
+                return Lists.partition(Collections.unmodifiableList(list), size);
+            }
+            if (collection.size() <= size) {
+                // Iterables.partition pre-allocates array of `size` waste when `items.size()` does not need partitioned
+                return ImmutableList.of(Collections.unmodifiableList(new ArrayList<>(collection)));
+            }
+        }
+        return Iterables.partition(items, size);
+    }
+}

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public final class MoreIterables {
@@ -46,19 +47,20 @@ public final class MoreIterables {
      * @param size the desired size of each sublist (the last may be smaller)
      * @return an iterable of unmodifiable lists containing the elements of {@code iterable} divided into partitions
      */
-    public static <T extends @Nullable Object> Iterable<? extends List<T>> partition(Iterable<T> items, int size) {
+    public static <T extends @Nullable Object> Iterable<List<T>> partition(Iterable<T> items, int size) {
         if (items instanceof Collection<T> collection) {
             // use Lists.partition if possible, which will return sublist without allocating entire
             // array of partition size.
             if (collection.isEmpty()) {
                 return ImmutableList.of();
             }
-            if (collection instanceof ImmutableCollection<T> immutableCollection) {
+            if (collection instanceof ImmutableCollection<@NonNull T> immutableCollection) {
                 // immutable collections have an internal list that can be partitioned without allocating sublists
                 return Lists.partition(immutableCollection.asList(), size);
             }
             if (collection instanceof List<T> list) {
-                return Lists.partition(Collections.unmodifiableList(list), size);
+                return Lists.transform(
+                        Lists.partition(Collections.unmodifiableList(list), size), Collections::unmodifiableList);
             }
             if (collection.size() <= size) {
                 // Iterables.partition pre-allocates array of `size` waste when `items.size()` does not need partitioned

--- a/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
@@ -1,0 +1,292 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.iterable;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MoreIterablesTest {
+
+    @Nested
+    class EmptyCollectionTests {
+
+        @Test
+        void shouldReturnEmptyIterableForEmptyList() {
+            assertThat(MoreIterables.partition(new ArrayList<String>(), 3)).isEmpty();
+            assertThat(MoreIterables.partition(List.of(), 3)).isEmpty();
+            assertThat(MoreIterables.partition(ImmutableList.of(), 3)).isEmpty();
+            assertThat(MoreIterables.partition(Iterables.concat(ImmutableList.of(), List.of()), 3))
+                    .isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyIterableForEmptySet() {
+            assertThat(MoreIterables.partition(new HashSet<String>(), 5)).isEmpty();
+            assertThat(MoreIterables.partition(Set.of(), 5)).isEmpty();
+            assertThat(MoreIterables.partition(ImmutableSet.of(), 5)).isEmpty();
+            assertThat(MoreIterables.partition(Iterables.concat(ImmutableSet.of(), Set.of()), 3))
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    class ListPartitionTests {
+
+        @Test
+        void shouldPartitionListIntoEvenChunks() {
+            List<Integer> list = List.of(1, 2, 3, 4, 5, 6);
+
+            assertThat(MoreIterables.partition(list, 2))
+                    .hasSize(3)
+                    .isEqualTo(List.of(List.of(1, 2), List.of(3, 4), List.of(5, 6)));
+        }
+
+        @Test
+        void shouldPartitionListWithRemainder() {
+            List<String> list = List.of("a", "b", "c", "d", "e");
+
+            assertThat(MoreIterables.partition(list, 3))
+                    .hasSize(2)
+                    .isEqualTo(List.of(List.of("a", "b", "c"), List.of("d", "e")));
+        }
+
+        @Test
+        void shouldHandleListSmallerThanPartitionSize() {
+            List<Integer> list = List.of(1, 2);
+
+            assertThat(MoreIterables.partition(list, 5)).hasSize(1).isEqualTo(List.of(List.of(1, 2)));
+        }
+
+        @Test
+        void shouldHandleListEqualToPartitionSize() {
+            assertThat(MoreIterables.partition(List.of("a", "b", "c"), 3))
+                    .hasSize(1)
+                    .isEqualTo(List.of(List.of("a", "b", "c")));
+        }
+
+        @Test
+        void shouldHandleSingleElementList() {
+            assertThat(MoreIterables.partition(List.of(42), 1)).hasSize(1).isEqualTo(List.of(List.of(42)));
+        }
+
+        @Test
+        @SuppressWarnings("JdkObsolete") // explicitly testing LinkedList
+        void shouldHandleLinkedList() {
+            assertThat(MoreIterables.partition(new LinkedList<String>(List.of("x", "y", "z", "w")), 2))
+                    .hasSize(2)
+                    .isEqualTo(List.of(List.of("x", "y"), List.of("z", "w")));
+        }
+    }
+
+    @Nested
+    class ImmutableCollectionTests {
+
+        @Test
+        void shouldPartitionImmutableList() {
+            assertThat(MoreIterables.partition(ImmutableList.of(1, 2, 3, 4, 5), 2))
+                    .hasSize(3)
+                    .isEqualTo(List.of(List.of(1, 2), List.of(3, 4), List.of(5)));
+        }
+
+        @Test
+        void shouldPartitionImmutableSet() {
+            assertThat(MoreIterables.partition(ImmutableSet.of("a", "b", "c", "d"), 3))
+                    .hasSize(2)
+                    .allSatisfy(partition -> assertThat(partition)
+                            .asInstanceOf(list(String.class))
+                            .isSubsetOf("a", "b", "c", "d"));
+        }
+
+        @Test
+        void shouldHandleImmutableListSmallerThanPartitionSize() {
+            assertThat(MoreIterables.partition(ImmutableList.of(1, 2), 10))
+                    .hasSize(1)
+                    .isEqualTo(List.of(List.of(1, 2)));
+        }
+    }
+
+    @Nested
+    class NonListCollectionTests {
+
+        @Test
+        void shouldPartitionHashSetLargerThanPartitionSize() {
+            Set<Integer> set = new HashSet<>(List.of(1, 2, 3, 4, 5, 6, 7));
+            int partitionSize = 3;
+
+            List<Integer> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(set, partitionSize))
+                    .hasSize(3)
+                    .asInstanceOf(iterable(Object.class))
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(Integer.class))
+                            .hasSizeLessThanOrEqualTo(partitionSize)
+                            .satisfies(allElements::addAll));
+
+            assertThat(allElements).containsExactlyInAnyOrderElementsOf(set);
+        }
+
+        @Test
+        void shouldHandleSetSmallerThanPartitionSize() {
+            Set<String> set = new HashSet<>(List.of("a", "b"));
+            int partitionSize = 5;
+
+            List<String> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(set, partitionSize))
+                    .hasSize(1)
+                    .asInstanceOf(iterable(Object.class))
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(String.class))
+                            .hasSizeLessThanOrEqualTo(partitionSize)
+                            .satisfies(allElements::addAll));
+        }
+
+        @Test
+        void shouldHandleSetEqualToPartitionSize() {
+            Set<Integer> set = new HashSet<>(List.of(1, 2, 3));
+
+            assertThat(MoreIterables.partition(set, 3)).hasSize(1).allSatisfy(partition -> assertThat(partition)
+                    .asInstanceOf(list(Integer.class))
+                    .containsExactlyInAnyOrderElementsOf(set));
+        }
+    }
+
+    @Nested
+    class NonCollectionIterableTests {
+
+        @Test
+        @SuppressWarnings({"RedundantMethodReference", "UnnecessaryMethodReference"}) // explicitly testing
+        void shouldPartitionCustomIterable() {
+            List<String> list = List.of("a", "b", "c", "d", "e");
+            int partitionSize = 2;
+
+            List<String> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(list::iterator, partitionSize))
+                    .hasSize(3)
+                    .asInstanceOf(iterable(Object.class))
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(String.class))
+                            .hasSizeLessThanOrEqualTo(partitionSize)
+                            .satisfies(allElements::addAll));
+            assertThat(allElements).containsExactlyElementsOf(list).isEqualTo(list);
+        }
+
+        @Test
+        @SuppressWarnings({"RedundantMethodReference", "UnnecessaryMethodReference"}) // explicitly testing
+        void shouldHandleIterableThatIsNotCollection() {
+            List<Integer> list = List.of(1, 2, 3);
+            int partitionSize = 10;
+
+            List<Integer> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(list::iterator, partitionSize))
+                    .hasSize(1)
+                    .asInstanceOf(iterable(Object.class))
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(Integer.class))
+                            .hasSizeLessThanOrEqualTo(partitionSize)
+                            .satisfies(allElements::addAll));
+            assertThat(allElements).containsExactlyElementsOf(list).isEqualTo(list);
+        }
+    }
+
+    @Nested
+    class UnmodifiabilityTests {
+
+        @Test
+        void shouldReturnUnmodifiableSublistsForCollection() {
+            List<Integer> list = new ArrayList<>(List.of(1, 2, 3));
+
+            List<Integer> firstPartition =
+                    MoreIterables.partition(list, 2).iterator().next();
+
+            assertThatThrownBy(() -> firstPartition.add(99)).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void shouldReturnUnmodifiableSublistsForSmallCollection() {
+            Set<String> set = new HashSet<>(List.of("a", "b"));
+
+            List<String> partition = MoreIterables.partition(set, 5).iterator().next();
+
+            assertThatThrownBy(partition::clear).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    class EdgeCaseTests {
+
+        @Test
+        void shouldHandlePartitionSizeOfOne() {
+            assertThat(MoreIterables.partition(List.of(1, 2, 3), 1))
+                    .hasSize(3)
+                    .isEqualTo(List.of(List.of(1), List.of(2), List.of(3)));
+        }
+
+        @Test
+        void shouldHandleLargePartitionSize() {
+            List<String> list = List.of("a", "b", "c");
+
+            assertThat(MoreIterables.partition(list, 1000)).hasSize(1).isEqualTo(List.of(List.of("a", "b", "c")));
+        }
+
+        @Test
+        void shouldHandleNullElements() {
+            assertThat(MoreIterables.partition(Arrays.asList("a", null, "c", null, "e"), 2))
+                    .hasSize(3)
+                    .isEqualTo(List.of(Arrays.asList("a", null), Arrays.asList("c", null), List.of("e")));
+        }
+    }
+
+    @Nested
+    class IteratorBehaviorTests {
+
+        @Test
+        void shouldNotSupportRemoveOnIterator() {
+            Iterator<? extends List<Integer>> iterator =
+                    MoreIterables.partition(List.of(1, 2, 3, 4), 2).iterator();
+
+            iterator.next();
+            assertThatThrownBy(iterator::remove).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void shouldAllowMultipleIterations() {
+            Iterable<? extends List<String>> result = MoreIterables.partition(List.of("a", "b", "c", "d"), 2);
+
+            List<List<String>> firstIteration = new ArrayList<>();
+            result.forEach(firstIteration::add);
+
+            List<List<String>> secondIteration = new ArrayList<>();
+            result.forEach(secondIteration::add);
+
+            assertThat(firstIteration).isEqualTo(secondIteration);
+        }
+    }
+}

--- a/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
@@ -105,7 +105,7 @@ class MoreIterablesTest {
         @Test
         @SuppressWarnings("JdkObsolete") // explicitly testing LinkedList
         void shouldHandleLinkedList() {
-            assertThat(MoreIterables.partition(new LinkedList<String>(List.of("x", "y", "z", "w")), 2))
+            assertThat(MoreIterables.partition(new LinkedList<>(List.of("x", "y", "z", "w")), 2))
                     .hasSize(2)
                     .isEqualTo(List.of(List.of("x", "y"), List.of("z", "w")));
         }
@@ -150,12 +150,12 @@ class MoreIterablesTest {
             assertThat(MoreIterables.partition(set, partitionSize))
                     .hasSize(3)
                     .asInstanceOf(iterable(Object.class))
-                    .allSatisfy(batch -> {
-                        assertThat(batch).asInstanceOf(list(Integer.class)).satisfies(ints -> {
-                            assertThat(ints).hasSizeLessThanOrEqualTo(partitionSize);
-                            allElements.addAll(ints);
-                        });
-                    });
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(Integer.class))
+                            .satisfies(ints -> {
+                                assertThat(ints).hasSizeLessThanOrEqualTo(partitionSize);
+                                allElements.addAll(ints);
+                            }));
             assertThat(allElements).containsExactlyInAnyOrderElementsOf(set);
         }
 
@@ -327,9 +327,8 @@ class MoreIterablesTest {
         void shouldReturnRandomAccessListsForArrayList() {
             List<Integer> arrayList = new ArrayList<>(List.of(1, 2, 3, 4, 5));
 
-            MoreIterables.partition(arrayList, 2).forEach(partition -> {
-                assertThat(partition).isInstanceOf(RandomAccess.class);
-            });
+            assertThat(MoreIterables.partition(arrayList, 2))
+                    .allSatisfy(partition -> assertThat(partition).isInstanceOf(RandomAccess.class));
         }
 
         @Test
@@ -337,9 +336,8 @@ class MoreIterablesTest {
         void shouldReturnRandomAccessListsForVector() {
             Vector<String> vector = new Vector<>(List.of("a", "b", "c", "d"));
 
-            MoreIterables.partition(vector, 2).forEach(partition -> {
-                assertThat(partition).isInstanceOf(RandomAccess.class);
-            });
+            assertThat(MoreIterables.partition(vector, 2))
+                    .allSatisfy(partition -> assertThat(partition).isInstanceOf(RandomAccess.class));
         }
 
         @Test
@@ -348,18 +346,16 @@ class MoreIterablesTest {
             List<Integer> linkedList = new LinkedList<>(List.of(1, 2, 3, 4));
 
             // LinkedList doesn't implement RandomAccess, so partitions shouldn't either
-            MoreIterables.partition(linkedList, 2).forEach(partition -> {
-                assertThat(partition).isNotInstanceOf(RandomAccess.class);
-            });
+            assertThat(MoreIterables.partition(linkedList, 2))
+                    .allSatisfy(partition -> assertThat(partition).isNotInstanceOf(RandomAccess.class));
         }
 
         @Test
         void shouldReturnRandomAccessListsForImmutableList() {
             ImmutableList<Integer> immutableList = ImmutableList.of(1, 2, 3, 4, 5, 6);
 
-            MoreIterables.partition(immutableList, 2).forEach(partition -> {
-                assertThat(partition).isInstanceOf(RandomAccess.class);
-            });
+            assertThat(MoreIterables.partition(immutableList, 2))
+                    .allSatisfy(partition -> assertThat(partition).isInstanceOf(RandomAccess.class));
         }
     }
 

--- a/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
@@ -23,13 +23,18 @@ import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.NavigableSet;
+import java.util.RandomAccess;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.Vector;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -145,11 +150,12 @@ class MoreIterablesTest {
             assertThat(MoreIterables.partition(set, partitionSize))
                     .hasSize(3)
                     .asInstanceOf(iterable(Object.class))
-                    .allSatisfy(batch -> assertThat(batch)
-                            .asInstanceOf(list(Integer.class))
-                            .hasSizeLessThanOrEqualTo(partitionSize)
-                            .satisfies(allElements::addAll));
-
+                    .allSatisfy(batch -> {
+                        assertThat(batch).asInstanceOf(list(Integer.class)).satisfies(ints -> {
+                            assertThat(ints).hasSizeLessThanOrEqualTo(partitionSize);
+                            allElements.addAll(ints);
+                        });
+                    });
             assertThat(allElements).containsExactlyInAnyOrderElementsOf(set);
         }
 
@@ -164,8 +170,11 @@ class MoreIterablesTest {
                     .asInstanceOf(iterable(Object.class))
                     .allSatisfy(batch -> assertThat(batch)
                             .asInstanceOf(list(String.class))
-                            .hasSizeLessThanOrEqualTo(partitionSize)
-                            .satisfies(allElements::addAll));
+                            .satisfies(strings -> {
+                                assertThat(strings).hasSizeLessThanOrEqualTo(partitionSize);
+                                allElements.addAll(strings);
+                            }));
+            assertThat(allElements).containsExactlyInAnyOrderElementsOf(set);
         }
 
         @Test
@@ -287,6 +296,245 @@ class MoreIterablesTest {
             result.forEach(secondIteration::add);
 
             assertThat(firstIteration).isEqualTo(secondIteration);
+        }
+    }
+
+    @Nested
+    class InvalidInputTests {
+
+        @Test
+        void shouldThrowExceptionForZeroPartitionSize() {
+            assertThatThrownBy(() -> MoreIterables.partition(List.of(1, 2, 3), 0))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldThrowExceptionForNegativePartitionSize() {
+            assertThatThrownBy(() -> MoreIterables.partition(List.of(1, 2, 3), -1))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldThrowExceptionForNullIterable() {
+            assertThatThrownBy(() -> MoreIterables.partition(null, 3)).isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    class RandomAccessTests {
+
+        @Test
+        void shouldReturnRandomAccessListsForArrayList() {
+            List<Integer> arrayList = new ArrayList<>(List.of(1, 2, 3, 4, 5));
+
+            MoreIterables.partition(arrayList, 2).forEach(partition -> {
+                assertThat(partition).isInstanceOf(RandomAccess.class);
+            });
+        }
+
+        @Test
+        @SuppressWarnings("JdkObsolete") // explicitly testing Vector
+        void shouldReturnRandomAccessListsForVector() {
+            Vector<String> vector = new Vector<>(List.of("a", "b", "c", "d"));
+
+            MoreIterables.partition(vector, 2).forEach(partition -> {
+                assertThat(partition).isInstanceOf(RandomAccess.class);
+            });
+        }
+
+        @Test
+        @SuppressWarnings("JdkObsolete") // explicitly testing LinkedList
+        void shouldNotReturnRandomAccessListsForLinkedList() {
+            List<Integer> linkedList = new LinkedList<>(List.of(1, 2, 3, 4));
+
+            // LinkedList doesn't implement RandomAccess, so partitions shouldn't either
+            MoreIterables.partition(linkedList, 2).forEach(partition -> {
+                assertThat(partition).isNotInstanceOf(RandomAccess.class);
+            });
+        }
+
+        @Test
+        void shouldReturnRandomAccessListsForImmutableList() {
+            ImmutableList<Integer> immutableList = ImmutableList.of(1, 2, 3, 4, 5, 6);
+
+            MoreIterables.partition(immutableList, 2).forEach(partition -> {
+                assertThat(partition).isInstanceOf(RandomAccess.class);
+            });
+        }
+    }
+
+    @Nested
+    class AdditionalCollectionTypeTests {
+
+        @Test
+        void shouldPartitionTreeSet() {
+            NavigableSet<Integer> treeSet = new TreeSet<>(List.of(5, 2, 8, 1, 9, 3, 7));
+            int partitionSize = 3;
+
+            List<Integer> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(treeSet, partitionSize))
+                    .hasSize(3)
+                    .asInstanceOf(iterable(Object.class))
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(Integer.class))
+                            .hasSizeLessThanOrEqualTo(partitionSize)
+                            .satisfies(allElements::addAll));
+
+            // TreeSet maintains sorted order
+            assertThat(allElements).containsExactly(1, 2, 3, 5, 7, 8, 9);
+        }
+
+        @Test
+        void shouldPartitionArrayDeque() {
+            ArrayDeque<String> deque = new ArrayDeque<>(List.of("a", "b", "c", "d", "e"));
+            int partitionSize = 2;
+
+            List<String> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(deque, partitionSize))
+                    .hasSize(3)
+                    .asInstanceOf(iterable(Object.class))
+                    .allSatisfy(batch -> assertThat(batch)
+                            .asInstanceOf(list(String.class))
+                            .hasSizeLessThanOrEqualTo(partitionSize)
+                            .satisfies(allElements::addAll));
+
+            assertThat(allElements).containsExactlyElementsOf(deque);
+        }
+
+        @Test
+        @SuppressWarnings("JdkObsolete") // explicitly testing Vector
+        void shouldPartitionVector() {
+            Vector<Integer> vector = new Vector<>(List.of(10, 20, 30, 40, 50, 60, 70));
+
+            assertThat(MoreIterables.partition(vector, 3))
+                    .hasSize(3)
+                    .isEqualTo(List.of(List.of(10, 20, 30), List.of(40, 50, 60), List.of(70)));
+        }
+
+        @Test
+        void shouldPartitionSmallTreeSet() {
+            NavigableSet<String> treeSet = new TreeSet<>(List.of("b", "a"));
+
+            assertThat(MoreIterables.partition(treeSet, 5)).hasSize(1).allSatisfy(partition -> assertThat(partition)
+                    .asInstanceOf(list(String.class))
+                    .containsExactly("a", "b"));
+        }
+
+        @Test
+        void shouldPartitionArrayDequeSmallerThanPartitionSize() {
+            ArrayDeque<Integer> deque = new ArrayDeque<>(List.of(1, 2));
+
+            assertThat(MoreIterables.partition(deque, 10)).hasSize(1).allSatisfy(partition -> assertThat(partition)
+                    .asInstanceOf(list(Integer.class))
+                    .containsExactly(1, 2));
+        }
+    }
+
+    @Nested
+    class LargerDatasetTests {
+
+        @Test
+        void shouldPartitionLargeList() {
+            List<Integer> largeList = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                largeList.add(i);
+            }
+
+            Iterable<? extends List<Integer>> partitions = MoreIterables.partition(largeList, 100);
+
+            assertThat(partitions).hasSize(10);
+
+            int index = 0;
+            for (List<Integer> partition : partitions) {
+                assertThat(partition).hasSize(100);
+                for (int value : partition) {
+                    assertThat(value).isEqualTo(index++);
+                }
+            }
+        }
+
+        @Test
+        void shouldPartitionLargeListWithRemainder() {
+            List<String> largeList = new ArrayList<>();
+            for (int i = 0; i < 1547; i++) {
+                largeList.add("item-" + i);
+            }
+
+            Iterable<? extends List<String>> partitions = MoreIterables.partition(largeList, 200);
+
+            assertThat(partitions).hasSize(8);
+
+            List<String> allElements = new ArrayList<>();
+            partitions.forEach(allElements::addAll);
+
+            assertThat(allElements).isEqualTo(largeList);
+        }
+
+        @Test
+        void shouldPartitionLargeImmutableList() {
+            ImmutableList.Builder<Integer> builder = ImmutableList.builder();
+            for (int i = 0; i < 500; i++) {
+                builder.add(i);
+            }
+            ImmutableList<Integer> immutableList = builder.build();
+
+            assertThat(MoreIterables.partition(immutableList, 50)).hasSize(10);
+        }
+
+        @Test
+        void shouldPartitionLargeHashSet() {
+            Set<Integer> largeSet = new HashSet<>();
+            for (int i = 0; i < 750; i++) {
+                largeSet.add(i);
+            }
+
+            Iterable<? extends List<Integer>> partitions = MoreIterables.partition(largeSet, 100);
+
+            List<Integer> allElements = new ArrayList<>();
+            partitions.forEach(allElements::addAll);
+
+            assertThat(allElements).containsExactlyInAnyOrderElementsOf(largeSet);
+        }
+    }
+
+    @Nested
+    class SpecificCodePathTests {
+
+        @Test
+        void shouldUseArrayListPathForNonListCollection() {
+            // This specifically tests the collection.size() <= size path for non-list collections
+            // which creates an ArrayList from the collection
+            Set<String> smallSet = new HashSet<>(List.of("x", "y", "z"));
+
+            Iterable<? extends List<String>> result = MoreIterables.partition(smallSet, 10);
+
+            assertThat(result).hasSize(1);
+            List<String> partition = result.iterator().next();
+            assertThat(partition).containsExactlyInAnyOrderElementsOf(smallSet);
+            assertThatThrownBy(() -> partition.add("new")).isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        void shouldUseFallbackPathForNonCollectionIterable() {
+            // Custom iterable that is not a Collection
+            Iterable<Integer> customIterable = () -> List.of(1, 2, 3, 4, 5).iterator();
+
+            List<Integer> allElements = new ArrayList<>();
+            assertThat(MoreIterables.partition(customIterable, 2)).hasSize(3).allSatisfy(batch -> assertThat(batch)
+                    .asInstanceOf(list(Integer.class))
+                    .satisfies(ints -> {
+                        assertThat(ints).hasSizeBetween(1, 2);
+                        allElements.addAll(ints);
+                    }));
+            assertThat(allElements).containsExactly(1, 2, 3, 4, 5);
+        }
+
+        @Test
+        void shouldHandleEmptyIteratorCorrectly() {
+            Iterable<? extends List<String>> emptyPartition = MoreIterables.partition(List.of(), 5);
+
+            Iterator<? extends List<String>> iterator = emptyPartition.iterator();
+            assertThat(iterator.hasNext()).isFalse();
         }
     }
 }

--- a/versions.lock
+++ b/versions.lock
@@ -10,7 +10,7 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 
 com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
-org.jspecify:jspecify:1.0.0 (7 constraints: 5370d26f)
+org.jspecify:jspecify:1.0.0 (8 constraints: 55759ae3)
 
 
 

--- a/versions.props
+++ b/versions.props
@@ -1,5 +1,6 @@
 com.google.guava:guava = 33.5.0-jre
 org.assertj:* = 3.27.7
+org.jspecify:* = 1.0.0
 org.junit.jupiter:* = 6.0.2
 org.junit.platform:* = 6.0.2
 org.mockito:* = 5.21.0


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Similar to Guava `Iterables#partition(Iterable, int)` and `Lists#partition(List, int)`; however, Guava `Iterables#partition(Iterable, int)` eagerly allocates array storage leading to excessive allocations with small or empty iterables, while this `MoreIterables#partition(Iterable, int)` implementation avoids excess allocations and delegates to more efficient `Lists#partition(List, int)` where possible (e.g. when provided iterable is an `ImmutableCollection` via `asList()`) which returns sublist views.

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

