### PR TITLE
Memory-efficient MoreIterables.forEachPartition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:7.4.0'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:5.0.0'
         classpath 'com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.8.0'
+        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.3'
     }
 }
 

--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     api 'com.google.guava:guava'
 
     implementation 'com.google.errorprone:error_prone_annotations'
+    implementation 'com.palantir.safe-logging:preconditions'
     implementation 'org.jspecify:jspecify'
 
     testImplementation 'org.assertj:assertj-core'

--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     implementation 'com.google.errorprone:error_prone_annotations'
     implementation 'com.palantir.safe-logging:preconditions'
+    implementation 'com.palantir.safe-logging:safe-logging'
     implementation 'org.jspecify:jspecify'
 
     testImplementation 'org.assertj:assertj-core'

--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.palantir.external-publish-jar'
+apply plugin: 'me.champeau.jmh'
 
 dependencies {
     api 'com.google.guava:guava'
@@ -14,4 +15,11 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'org.mockito:mockito-junit-jupiter'
+
+    jmh 'org.openjdk.jmh:jmh-core'
+    jmh 'org.openjdk.jmh:jmh-generator-annprocess'
+}
+
+jmh {
+    profilers = ['gc']
 }

--- a/streams/src/jmh/java/com/palantir/common/streams/MoreIterablesBenchmark.java
+++ b/streams/src/jmh/java/com/palantir/common/streams/MoreIterablesBenchmark.java
@@ -58,6 +58,7 @@ import org.openjdk.jmh.infra.Blackhole;
 // HASH_SET                               48,307             414,147
 // TREE_SET                               48,195             414,147
 // HASH_MAP_ENTRIES                       48,307             414,147
+// CUSTOM_ITERABLE                        48,307             414,147
 //
 // size=50000
 // Collection Type                  forEachPartition    partition.forEach
@@ -70,6 +71,7 @@ import org.openjdk.jmh.infra.Blackhole;
 // HASH_SET                               47,915           2,039,747
 // TREE_SET                               47,907           2,039,747
 // HASH_MAP_ENTRIES                       47,768           2,039,747
+// CUSTOM_ITERABLE                        48,211           2,039,747
 @State(Scope.Benchmark)
 @Fork(value = 2)
 @Warmup(iterations = 1, batchSize = 10)
@@ -87,6 +89,7 @@ public class MoreIterablesBenchmark {
         HASH_SET,
         TREE_SET,
         HASH_MAP_ENTRIES,
+        CUSTOM_ITERABLE
     }
 
     @Param({"10000", "50000"})
@@ -124,6 +127,7 @@ public class MoreIterablesBenchmark {
             case HASH_MAP_ENTRIES ->
                 new HashMap<>(elements.stream().collect(Collectors.toMap(Function.identity(), Function.identity())))
                         .entrySet();
+            case CUSTOM_ITERABLE -> (Iterable<Integer>) elements::iterator;
         };
     }
 

--- a/streams/src/jmh/java/com/palantir/common/streams/MoreIterablesBenchmark.java
+++ b/streams/src/jmh/java/com/palantir/common/streams/MoreIterablesBenchmark.java
@@ -1,0 +1,139 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.streams;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+// The benchmarks demonstrate that:
+//  1. forEachPartition and partition.forEach allocate roughly equal memory for list and immutable collection types
+//  2. forEachPartition allocates less memory than partition.forEach for other collection types, such as HashSet
+//  3. forEachPartition space complexity is O(min(partitionSize, size)) compared to O(size) for partition.forEach
+//
+// gc.alloc.rate.norm (B/op), partitionSize=1000
+//
+// size=10000
+// Collection Type                  forEachPartition    partition.forEach
+// ---------------------------------------------------------------------
+// ARRAY_LIST                             13,678              13,598
+// IMMUTABLE_LIST                         10,318               9,918
+// IMMUTABLE_SET                          10,336               9,936
+// IMMUTABLE_MAP_ENTRIES                  10,318               9,918
+// IMMUTABLE_SET_MULTIMAP_ENTRIES      5,211,357           5,210,954
+// HASH_SET                               48,307             414,147
+// TREE_SET                               48,195             414,147
+// HASH_MAP_ENTRIES                       48,307             414,147
+//
+// size=50000
+// Collection Type                  forEachPartition    partition.forEach
+// ---------------------------------------------------------------------
+// ARRAY_LIST                             36,067              36,037
+// IMMUTABLE_LIST                         19,907              19,606
+// IMMUTABLE_SET                          20,045              19,546
+// IMMUTABLE_MAP_ENTRIES                  20,059              19,610
+// IMMUTABLE_SET_MULTIMAP_ENTRIES     26,020,782          26,020,333
+// HASH_SET                               47,915           2,039,747
+// TREE_SET                               47,907           2,039,747
+// HASH_MAP_ENTRIES                       47,768           2,039,747
+@State(Scope.Benchmark)
+@Fork(value = 2)
+@Warmup(iterations = 1, batchSize = 10)
+@Measurement(iterations = 5, batchSize = 10)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class MoreIterablesBenchmark {
+
+    public enum IterableType {
+        ARRAY_LIST,
+        IMMUTABLE_LIST,
+        IMMUTABLE_SET,
+        IMMUTABLE_MAP_ENTRIES,
+        IMMUTABLE_SET_MULTIMAP_ENTRIES,
+        HASH_SET,
+        TREE_SET,
+        HASH_MAP_ENTRIES,
+    }
+
+    @Param({"10000", "50000"})
+    private int size;
+
+    @Param("1000")
+    private int partitionSize;
+
+    @Param
+    private IterableType iterableType;
+
+    private Iterable<?> iterable;
+
+    @Setup
+    public final void setup() {
+        List<Integer> elements = new ArrayList<>();
+        for (int i = 0; i < size; ++i) {
+            elements.add(i);
+        }
+
+        iterable = switch (iterableType) {
+            case ARRAY_LIST -> new ArrayList<>(elements);
+            case IMMUTABLE_LIST -> ImmutableList.copyOf(elements);
+            case IMMUTABLE_SET -> ImmutableSet.copyOf(elements);
+            case IMMUTABLE_MAP_ENTRIES ->
+                ImmutableMap.copyOf(
+                                elements.stream().collect(Collectors.toMap(Function.identity(), Function.identity())))
+                        .entrySet();
+            case IMMUTABLE_SET_MULTIMAP_ENTRIES ->
+                elements.stream()
+                        .collect(ImmutableSetMultimap.toImmutableSetMultimap(Function.identity(), Function.identity()))
+                        .entries();
+            case HASH_SET -> new HashSet<>(elements);
+            case TREE_SET -> new TreeSet<>(elements);
+            case HASH_MAP_ENTRIES ->
+                new HashMap<>(elements.stream().collect(Collectors.toMap(Function.identity(), Function.identity())))
+                        .entrySet();
+        };
+    }
+
+    @Benchmark
+    public final void forEachPartition(Blackhole blackhole) {
+        MoreIterables.forEachPartition(iterable, partitionSize, blackhole::consume);
+    }
+
+    @Benchmark
+    public final void partitionForEach(Blackhole blackhole) {
+        MoreIterables.partition(iterable, partitionSize).forEach(blackhole::consume);
+    }
+}

--- a/streams/src/jmh/java/com/palantir/common/streams/MoreIterablesBenchmark.java
+++ b/streams/src/jmh/java/com/palantir/common/streams/MoreIterablesBenchmark.java
@@ -101,7 +101,7 @@ public class MoreIterablesBenchmark {
     private Iterable<?> iterable;
 
     @Setup
-    public final void setup() {
+    public final void before() {
         List<Integer> elements = new ArrayList<>();
         for (int i = 0; i < size; ++i) {
             elements.add(i);

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -94,23 +94,23 @@ public final class MoreIterables {
      */
     public static <T extends @Nullable Object> void forEachPartition(
             Iterable<T> items, int size, Consumer<List<T>> consumer) {
-        checkNotNull(items);
-        checkNotNull(consumer);
+        checkNotNull(items, "items must not be null");
+        checkNotNull(consumer, "consumer must not be null");
         checkArgument(size > 0, "size must be greater than zero", SafeArg.of("size", size));
 
-        Iterator<T> iterator = items.iterator();
-        if (!iterator.hasNext()) {
-            return;
-        }
-
         if (items instanceof ImmutableCollection<@NonNull T> immutableCollection) {
-            // Each immutable collection has an internal list that can leverage Lists.partition.
+            // Many immutable collections have an internal list that can leverage Lists.partition.
             Lists.partition(immutableCollection.asList(), size).forEach(consumer);
             return;
         }
         if (items instanceof List<T> list) {
             // Lists.partition creates sublist views without copying elements.
             Lists.partition(list, size).forEach(partition -> consumer.accept(Collections.unmodifiableList(partition)));
+            return;
+        }
+
+        Iterator<T> iterator = items.iterator();
+        if (!iterator.hasNext()) {
             return;
         }
 

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -103,16 +103,17 @@ public final class MoreIterables {
         }
 
         if (items instanceof List<T> list) {
+            // Lists.partition creates sublist views without copying elements.
             Lists.partition(list, size).forEach(partition -> consumer.accept(Collections.unmodifiableList(partition)));
             return;
         }
         if (items instanceof ImmutableCollection<@NonNull T> immutableCollection) {
-            // Immutable collections have an internal list that can be partitioned without allocating sublists.
+            // Each immutable collection has an internal list that can leverage Lists.partition.
             Lists.partition(immutableCollection.asList(), size).forEach(consumer);
             return;
         }
 
-        // Avoid over-allocation when the items size is less than the partition size.
+        // Avoid over-allocation when the iterable (collection) size is less than the partition size.
         int arraySize = (items instanceof Collection<T> collection) ? Math.min(size, collection.size()) : size;
 
         @SuppressWarnings("unchecked") // We only put Ts in the array.

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -82,7 +82,7 @@ public final class MoreIterables {
      * a partition size of 3 invokes the consumer twice, once on {@code [a, b, c]} and once on {@code [d, e]}. All
      * elements remain in the original order. The consumer is never invoked if the iterable is empty.
      * <p>
-     * Unlike {@link MoreIterables#partition(Iterable, int)}, each sublist must be processed independently, and
+     * Unlike {@link MoreIterables#partition(Iterable, int)}, each sublist must be processed independently, meaning
      * references to sublists must not be captured outside the consumer. For non-list iterables,
      * {@link #partition(Iterable, int)} allocates a new list per sublist while this implementation allocates only
      * enough storage for one sublist by reusing a single backing array across sublists. Prefer this method if sublists

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -15,13 +15,14 @@
  */
 package com.palantir.common.streams;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.palantir.logsafe.Preconditions.checkArgument;
+import static com.palantir.logsafe.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.palantir.logsafe.SafeArg;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -95,21 +96,21 @@ public final class MoreIterables {
             Iterable<T> items, int size, Consumer<List<T>> consumer) {
         checkNotNull(items);
         checkNotNull(consumer);
-        checkArgument(size > 0);
+        checkArgument(size > 0, "size must be greater than zero", SafeArg.of("size", size));
 
         Iterator<T> iterator = items.iterator();
         if (!iterator.hasNext()) {
             return;
         }
 
-        if (items instanceof List<T> list) {
-            // Lists.partition creates sublist views without copying elements.
-            Lists.partition(list, size).forEach(partition -> consumer.accept(Collections.unmodifiableList(partition)));
-            return;
-        }
         if (items instanceof ImmutableCollection<@NonNull T> immutableCollection) {
             // Each immutable collection has an internal list that can leverage Lists.partition.
             Lists.partition(immutableCollection.asList(), size).forEach(consumer);
+            return;
+        }
+        if (items instanceof List<T> list) {
+            // Lists.partition creates sublist views without copying elements.
+            Lists.partition(list, size).forEach(partition -> consumer.accept(Collections.unmodifiableList(partition)));
             return;
         }
 

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -116,7 +116,7 @@ public final class MoreIterables {
         // Avoid over-allocation when the iterable (collection) size is less than the partition size.
         int arraySize = (items instanceof Collection<T> collection) ? Math.min(size, collection.size()) : size;
 
-        @SuppressWarnings("unchecked") // We only put Ts in the array.
+        @SuppressWarnings("unchecked") // We put only Ts in the array.
         T[] array = (T[]) new Object[arraySize];
 
         List<T> partition = Collections.unmodifiableList(Arrays.asList(array));

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -99,7 +99,10 @@ public final class MoreIterables {
         checkArgument(size > 0, "size must be greater than zero", SafeArg.of("size", size));
 
         if (items instanceof ImmutableCollection<@NonNull T> immutableCollection) {
-            // Many immutable collections have an internal list that can leverage Lists.partition.
+            // Many immutable collections have an internal list that can leverage Lists.partition. Some, such as
+            // ImmutableSetMultimap.EntrySet, do not, but these are rare and not easily identifiable. We prefer to be
+            // efficient on most ImmutableCollection implementations at the cost of having similar performance to
+            // partition.forEach for these rare edge cases.
             Lists.partition(immutableCollection.asList(), size).forEach(consumer);
             return;
         }

--- a/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreIterables.java
@@ -15,14 +15,20 @@
  */
 package com.palantir.common.streams;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -67,5 +73,58 @@ public final class MoreIterables {
             }
         }
         return Iterables.partition(items, size);
+    }
+
+    /**
+     * Divides an iterable into unmodifiable sublists of the given size (the final sublist may be smaller) and passes
+     * each sublist to the given consumer. For example, partitioning an iterable containing {@code [a, b, c, d, e]} with
+     * a partition size of 3 invokes the consumer twice, once on {@code [a, b, c]} and once on {@code [d, e]}. All
+     * elements remain in the original order. The consumer is never invoked if the iterable is empty.
+     * <p>
+     * Unlike {@link MoreIterables#partition(Iterable, int)}, each sublist must be processed independently, and
+     * references to sublists must not be captured outside the consumer. For non-list iterables,
+     * {@link #partition(Iterable, int)} allocates a new list per sublist while this implementation allocates only
+     * enough storage for one sublist by reusing a single backing array across sublists. Prefer this method if sublists
+     * are processed independently.
+     *
+     * @param items the iterable to partition and consume
+     * @param size the desired size of each sublist (the last may be smaller)
+     * @param consumer the consumer of each sublist
+     */
+    public static <T extends @Nullable Object> void forEachPartition(
+            Iterable<T> items, int size, Consumer<List<T>> consumer) {
+        checkNotNull(items);
+        checkNotNull(consumer);
+        checkArgument(size > 0);
+
+        Iterator<T> iterator = items.iterator();
+        if (!iterator.hasNext()) {
+            return;
+        }
+
+        if (items instanceof List<T> list) {
+            Lists.partition(list, size).forEach(partition -> consumer.accept(Collections.unmodifiableList(partition)));
+            return;
+        }
+        if (items instanceof ImmutableCollection<@NonNull T> immutableCollection) {
+            // Immutable collections have an internal list that can be partitioned without allocating sublists.
+            Lists.partition(immutableCollection.asList(), size).forEach(consumer);
+            return;
+        }
+
+        // Avoid over-allocation when the items size is less than the partition size.
+        int arraySize = (items instanceof Collection<T> collection) ? Math.min(size, collection.size()) : size;
+
+        @SuppressWarnings("unchecked") // We only put Ts in the array.
+        T[] array = (T[]) new Object[arraySize];
+
+        List<T> partition = Collections.unmodifiableList(Arrays.asList(array));
+        do { // We already confirmed that the iterator has an item.
+            int count = 0;
+            for (; count < size && iterator.hasNext(); ++count) {
+                array[count] = iterator.next();
+            }
+            consumer.accept(count == size ? partition : partition.subList(0, count));
+        } while (iterator.hasNext());
     }
 }

--- a/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
@@ -507,13 +507,13 @@ class MoreIterablesTest {
 
         @Test
         void forEachShouldThrowExceptionForNullIterable() {
-            assertThatThrownBy(() -> MoreIterables.forEachPartition(null, -1, _partition -> fail()))
+            assertThatThrownBy(() -> MoreIterables.forEachPartition(null, 1, _partition -> fail()))
                     .isInstanceOf(NullPointerException.class);
         }
 
         @Test
         void forEachShouldThrowExceptionForNullConsumer() {
-            assertThatThrownBy(() -> MoreIterables.forEachPartition(Set.of(1, 2, 3), -1, null))
+            assertThatThrownBy(() -> MoreIterables.forEachPartition(Set.of(1, 2, 3), 1, null))
                     .isInstanceOf(NullPointerException.class);
         }
     }

--- a/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
@@ -17,6 +17,7 @@ package com.palantir.common.streams;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static org.assertj.core.api.InstanceOfAssertFactories.iterable;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
@@ -35,6 +36,7 @@ import java.util.RandomAccess;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Vector;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +61,22 @@ class MoreIterablesTest {
             assertThat(MoreIterables.partition(ImmutableSet.of(), 5)).isEmpty();
             assertThat(MoreIterables.partition(Iterables.concat(ImmutableSet.of(), Set.of()), 3))
                     .isEmpty();
+        }
+
+        @Test
+        void shouldNotInvokeConsumerForEmptyList() {
+            MoreIterables.forEachPartition(new ArrayList<>(), 3, _partition -> fail());
+            MoreIterables.forEachPartition(List.of(), 3, _partition -> fail());
+            MoreIterables.forEachPartition(ImmutableList.of(), 3, _partition -> fail());
+            MoreIterables.forEachPartition(Iterables.concat(ImmutableList.of(), List.of()), 3, _partition -> fail());
+        }
+
+        @Test
+        void shouldNotInvokeConsumerForEmptySet() {
+            MoreIterables.forEachPartition(new HashSet<>(), 3, _partition -> fail());
+            MoreIterables.forEachPartition(Set.of(), 3, _partition -> fail());
+            MoreIterables.forEachPartition(ImmutableSet.of(), 3, _partition -> fail());
+            MoreIterables.forEachPartition(Iterables.concat(ImmutableSet.of(), Set.of()), 3, _partition -> fail());
         }
     }
 
@@ -109,6 +127,41 @@ class MoreIterablesTest {
                     .hasSize(2)
                     .containsExactly(List.of("x", "y"), List.of("z", "w"));
         }
+
+        @Test
+        void shouldConsumeListInEvenChunks() {
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    List.of(1, 2, 3, 4, 5, 6), 2, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(3).containsExactly(List.of(1, 2), List.of(3, 4), List.of(5, 6));
+        }
+
+        @Test
+        void shouldConsumeListWithRemainder() {
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    List.of("a", "b", "c", "d", "e"), 3, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(2).containsExactly(List.of("a", "b", "c"), List.of("d", "e"));
+        }
+
+        @Test
+        void shouldConsumeListSmallerThanPartitionSize() {
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(List.of(1, 2), 5, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(1).containsExactly(List.of(1, 2));
+        }
+
+        @Test
+        void shouldConsumeListEqualToPartitionSize() {
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    List.of("a", "b", "c"), 3, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(1).containsExactly(List.of("a", "b", "c"));
+        }
     }
 
     @Nested
@@ -135,6 +188,28 @@ class MoreIterablesTest {
             assertThat(MoreIterables.partition(ImmutableList.of(1, 2), 10))
                     .hasSize(1)
                     .containsExactly(List.of(1, 2));
+        }
+
+        @Test
+        void shouldConsumeImmutableList() {
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    ImmutableList.of(1, 2, 3, 4, 5), 2, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(3).containsExactly(List.of(1, 2), List.of(3, 4), List.of(5));
+        }
+
+        @Test
+        void shouldConsumeImmutableSet() {
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    ImmutableSet.of("a", "b", "c", "d"), 3, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions)
+                    .hasSize(2)
+                    .allSatisfy(partition -> assertThat(partition)
+                            .asInstanceOf(list(String.class))
+                            .isSubsetOf("a", "b", "c", "d"));
         }
     }
 
@@ -187,6 +262,44 @@ class MoreIterablesTest {
                             .asInstanceOf(list(Integer.class))
                             .containsExactlyInAnyOrderElementsOf(set));
         }
+
+        @Test
+        void shouldConsumeHashSetLargerThanPartitionSize() {
+            Set<Integer> set = new HashSet<>(List.of(1, 2, 3, 4, 5, 6, 7));
+            int partitionSize = 3;
+
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(set, partitionSize, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions)
+                    .hasSize(3)
+                    .allSatisfy(partition -> assertThat(partition).hasSizeLessThanOrEqualTo(partitionSize));
+            assertThat(partitions.stream().flatMap(List::stream).toList()).containsExactlyInAnyOrderElementsOf(set);
+        }
+
+        @Test
+        void shouldConsumeHashSetSmallerThanPartitionSize() {
+            Set<String> set = new HashSet<>(List.of("a", "b"));
+            int partitionSize = 5;
+
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(set, partitionSize, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(1);
+            assertThat(partitions.stream().flatMap(List::stream).toList()).containsExactlyInAnyOrderElementsOf(set);
+        }
+
+        @Test
+        void shouldConsumeHashSetEqualToPartitionSize() {
+            Set<Integer> set = new HashSet<>(List.of(1, 2, 3));
+            int partitionSize = 3;
+
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(set, partitionSize, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(1);
+            assertThat(partitions.get(0)).containsExactlyInAnyOrderElementsOf(set);
+        }
     }
 
     @Nested
@@ -225,6 +338,22 @@ class MoreIterablesTest {
                             .satisfies(allElements::addAll));
             assertThat(allElements).containsExactlyElementsOf(list).containsExactlyElementsOf(list);
         }
+
+        @Test
+        @SuppressWarnings({"RedundantMethodReference", "UnnecessaryMethodReference"}) // explicitly testing
+        void shouldConsumeCustomIterable() {
+            List<String> list = List.of("a", "b", "c", "d", "e");
+            int partitionSize = 2;
+
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    list::iterator, partitionSize, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions)
+                    .hasSize(3)
+                    .allSatisfy(partition -> assertThat(partition).hasSizeLessThanOrEqualTo(partitionSize));
+            assertThat(partitions.stream().flatMap(List::stream).toList()).containsExactlyElementsOf(list);
+        }
     }
 
     @Nested
@@ -248,6 +377,20 @@ class MoreIterablesTest {
 
             assertThatThrownBy(partition::clear).isInstanceOf(UnsupportedOperationException.class);
         }
+
+        @Test
+        void shouldConsumeUnmodifiableSublistsForList() {
+            MoreIterables.forEachPartition(new ArrayList<>(List.of(1, 2, 3)), 2, partition -> {
+                assertThatThrownBy(() -> partition.add(99)).isInstanceOf(UnsupportedOperationException.class);
+            });
+        }
+
+        @Test
+        void shouldConsumeUnmodifiableSublistsForHashSet() {
+            MoreIterables.forEachPartition(new HashSet<>(List.of(1, 2, 3)), 2, partition -> {
+                assertThatThrownBy(() -> partition.add(99)).isInstanceOf(UnsupportedOperationException.class);
+            });
+        }
     }
 
     @Nested
@@ -270,6 +413,35 @@ class MoreIterablesTest {
         @Test
         void shouldHandleNullElements() {
             assertThat(MoreIterables.partition(Arrays.asList("a", null, "c", null, "e"), 2))
+                    .hasSize(3)
+                    .containsExactly(Arrays.asList("a", null), Arrays.asList("c", null), List.of("e"));
+        }
+
+        @Test
+        void shouldConsumePartitionSizeOfOne() {
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(List.of(1, 2, 3), 1, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(3).containsExactly(List.of(1), List.of(2), List.of(3));
+        }
+
+        @Test
+        void shouldConsumeLargePartitionSize() {
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    List.of("a", "b", "c"), 1000, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(1).containsExactly(List.of("a", "b", "c"));
+        }
+
+        @Test
+        void shouldConsumeNullElements() {
+            List<@Nullable String> listWithNullElements = Arrays.asList("a", null, "c", null, "e");
+            List<List<@Nullable String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    listWithNullElements, 2, partition -> partitions.add(new ArrayList<>(partition)));
+
+            assertThat(partitions)
                     .hasSize(3)
                     .containsExactly(Arrays.asList("a", null), Arrays.asList("c", null), List.of("e"));
         }
@@ -319,6 +491,30 @@ class MoreIterablesTest {
         @Test
         void shouldThrowExceptionForNullIterable() {
             assertThatThrownBy(() -> MoreIterables.partition(null, 3)).isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void forEachShouldThrowExceptionForZeroPartitionSize() {
+            assertThatThrownBy(() -> MoreIterables.forEachPartition(Set.of(1, 2, 3), 0, _partition -> fail()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void forEachShouldThrowExceptionForNegativePartitionSize() {
+            assertThatThrownBy(() -> MoreIterables.forEachPartition(Set.of(1, 2, 3), -1, _partition -> fail()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void forEachShouldThrowExceptionForNullIterable() {
+            assertThatThrownBy(() -> MoreIterables.forEachPartition(null, -1, _partition -> fail()))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void forEachShouldThrowExceptionForNullConsumer() {
+            assertThatThrownBy(() -> MoreIterables.forEachPartition(Set.of(1, 2, 3), -1, null))
+                    .isInstanceOf(NullPointerException.class);
         }
     }
 

--- a/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
+++ b/streams/src/test/java/com/palantir/common/streams/MoreIterablesTest.java
@@ -626,6 +626,35 @@ class MoreIterablesTest {
                             .asInstanceOf(list(Integer.class))
                             .containsExactly(1, 2));
         }
+
+        @Test
+        void shouldConsumeTreeSet() {
+            NavigableSet<Integer> treeSet = new TreeSet<>(List.of(5, 2, 8, 1, 9, 3, 7));
+            int partitionSize = 3;
+
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(treeSet, partitionSize, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions)
+                    .hasSize(3)
+                    .allSatisfy(partition -> assertThat(partition).hasSizeLessThanOrEqualTo(partitionSize));
+            // TreeSet maintains sorted order
+            assertThat(partitions.stream().flatMap(List::stream).toList()).containsExactly(1, 2, 3, 5, 7, 8, 9);
+        }
+
+        @Test
+        void shouldConsumeArrayDeque() {
+            ArrayDeque<String> deque = new ArrayDeque<>(List.of("a", "b", "c", "d", "e"));
+            int partitionSize = 2;
+
+            List<List<String>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(deque, partitionSize, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions)
+                    .hasSize(3)
+                    .allSatisfy(partition -> assertThat(partition).hasSizeLessThanOrEqualTo(partitionSize));
+            assertThat(partitions.stream().flatMap(List::stream).toList()).containsExactlyElementsOf(deque);
+        }
     }
 
     @Nested
@@ -692,6 +721,65 @@ class MoreIterablesTest {
             partitions.forEach(allElements::addAll);
 
             assertThat(allElements).containsExactlyInAnyOrderElementsOf(largeSet);
+        }
+
+        @Test
+        void shouldConsumeLargeList() {
+            List<Integer> largeList = new ArrayList<>();
+            for (int i = 0; i < 1000; i++) {
+                largeList.add(i);
+            }
+
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(largeList, 100, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(10);
+            int index = 0;
+            for (List<Integer> partition : partitions) {
+                assertThat(partition).hasSize(100);
+                for (int value : partition) {
+                    assertThat(value).isEqualTo(index++);
+                }
+            }
+        }
+
+        @Test
+        void shouldConsumeLargeImmutableList() {
+            ImmutableList.Builder<Integer> builder = ImmutableList.builder();
+            for (int i = 0; i < 1000; i++) {
+                builder.add(i);
+            }
+            ImmutableList<Integer> largeImmutableList = builder.build();
+
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(
+                    largeImmutableList, 100, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions).hasSize(10);
+            int index = 0;
+            for (List<Integer> partition : partitions) {
+                assertThat(partition).hasSize(100);
+                for (int value : partition) {
+                    assertThat(value).isEqualTo(index++);
+                }
+            }
+        }
+
+        @Test
+        void shouldConsumeLargeHashSet() {
+            Set<Integer> largeSet = new HashSet<>();
+            for (int i = 0; i < 1000; i++) {
+                largeSet.add(i);
+            }
+
+            List<List<Integer>> partitions = new ArrayList<>();
+            MoreIterables.forEachPartition(largeSet, 100, partition -> partitions.add(List.copyOf(partition)));
+
+            assertThat(partitions)
+                    .hasSize(10)
+                    .allSatisfy(partition -> assertThat(partition).hasSize(100));
+            assertThat(partitions.stream().flatMap(List::stream).toList())
+                    .containsExactlyInAnyOrderElementsOf(largeSet);
         }
     }
 

--- a/versions.lock
+++ b/versions.lock
@@ -12,7 +12,7 @@ com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
 com.palantir.safe-logging:preconditions:3.13.0 (1 constraints: 39053e3b)
 
-com.palantir.safe-logging:safe-logging:3.13.0 (1 constraints: 331160d1)
+com.palantir.safe-logging:safe-logging:3.13.0 (2 constraints: 6b16740c)
 
 org.jetbrains:annotations:26.1.0 (1 constraints: 351170d1)
 

--- a/versions.lock
+++ b/versions.lock
@@ -1,6 +1,6 @@
 # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
 
-com.google.errorprone:error_prone_annotations:2.41.0 (1 constraints: 490a3ebf)
+com.google.errorprone:error_prone_annotations:2.41.0 (2 constraints: 4c1b146d)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
@@ -9,6 +9,12 @@ com.google.guava:guava:33.5.0-jre (1 constraints: ab068053)
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
 com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
+
+com.palantir.safe-logging:preconditions:3.13.0 (1 constraints: 39053e3b)
+
+com.palantir.safe-logging:safe-logging:3.13.0 (1 constraints: 331160d1)
+
+org.jetbrains:annotations:26.1.0 (1 constraints: 351170d1)
 
 org.jspecify:jspecify:1.0.0 (8 constraints: 55759ae3)
 

--- a/versions.lock
+++ b/versions.lock
@@ -26,6 +26,10 @@ net.bytebuddy:byte-buddy:1.18.3 (2 constraints: 9c16b43e)
 
 net.bytebuddy:byte-buddy-agent:1.17.7 (1 constraints: 4a0b4ede)
 
+net.sf.jopt-simple:jopt-simple:5.0.4 (1 constraints: be0ad6cc)
+
+org.apache.commons:commons-math3:3.6.1 (1 constraints: bf0adbcc)
+
 org.apiguardian:apiguardian-api:1.1.2 (6 constraints: 5366ce6e)
 
 org.assertj:assertj-core:3.27.7 (1 constraints: 4505553b)
@@ -50,4 +54,16 @@ org.mockito:mockito-junit-jupiter:5.23.0 (1 constraints: 3c054e3b)
 
 org.objenesis:objenesis:3.3 (1 constraints: b20a14bd)
 
+org.openjdk.jmh:jmh-core:1.37 (5 constraints: 52476be6)
+
+org.openjdk.jmh:jmh-generator-annprocess:1.37 (1 constraints: df04fc30)
+
+org.openjdk.jmh:jmh-generator-asm:1.37 (1 constraints: 2c107598)
+
+org.openjdk.jmh:jmh-generator-bytecode:1.37 (1 constraints: de04fb30)
+
+org.openjdk.jmh:jmh-generator-reflection:1.37 (2 constraints: 491e3064)
+
 org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)
+
+org.ow2.asm:asm:9.0 (1 constraints: ec0d4f34)

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,5 @@
 com.google.guava:guava = 33.5.0-jre
+com.palantir.safe-logging:* = 3.13.0
 org.assertj:* = 3.27.7
 org.jspecify:* = 1.0.0
 org.junit.jupiter:* = 6.0.3

--- a/versions.props
+++ b/versions.props
@@ -5,3 +5,4 @@ org.jspecify:* = 1.0.0
 org.junit.jupiter:* = 6.0.3
 org.junit.platform:* = 6.0.3
 org.mockito:* = 5.23.0
+org.openjdk.jmh:* = 1.37


### PR DESCRIPTION
```
public static <T extends @Nullable Object> void forEachPartition(
        Iterable<T> items, int size, Consumer<List<T>> consumer);
```
Adds a new `MoreIterables.forEachPartition` method that divides an iterable into unmodifiable sublists of a given size and passes each to a consumer.

Unlike the existing `MoreIterables.partition` method, this implementation reuses a single backing array across sublists rather than allocating a new list per sublist, making it more memory-efficient when sublists are processed independently. Note that this means sublists must not be captured outside the consumer since the backing array is reused across partitions.

This method should be preferred over `MoreIterables.partition` if partitions are processed sequentially and independently, which is common.
```
Set<String> largeHashSet = IntStream.range(0, 1_000_000)
        .mapToObj(_i -> UUID.randomUUID().toString())
        .collect(Collectors.toCollection(HashSet::new));
int smallPartitionSize = 10;

// inefficient because we allocate space for 10 * 100_000 = 1_000_000 objects, though allocations are lazy
MoreIterables.partition(largeHashSet, smallPartitionSize).forEach(process);

// efficient because we allocate space for 10 objects
MoreIterables.forEachPartition(largeHashSet, smallPartitionSize, process);
```