### PR TITLE
Add eager blockingStreamWithParallelism

### DIFF
--- a/streams/src/main/java/com/palantir/common/streams/EagerBufferingSpliterator.java
+++ b/streams/src/main/java/com/palantir/common/streams/EagerBufferingSpliterator.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Spliterator;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorCompletionService;
@@ -51,7 +52,7 @@ class EagerBufferingSpliterator<T, U> implements Spliterator<T> {
         this.source = source;
         this.mapper = mapper;
         this.maxParallelism = maxParallelism;
-        this.completionService = new ExecutorCompletionService<>(executor);
+        this.completionService = new ExecutorCompletionService<>(executor, new ArrayBlockingQueue<>(maxParallelism));
     }
 
     @Override
@@ -84,17 +85,16 @@ class EagerBufferingSpliterator<T, U> implements Spliterator<T> {
 
     private void startWorkEagerly() {
         while (!sourceExhausted && inFlight < maxParallelism) {
-            ValueHolder<U> holder = new ValueHolder<>();
-            boolean hasMore = source.tryAdvance(input -> holder.value = input);
+            boolean hasMore = source.tryAdvance(input -> {
+                long index = nextIndexToStart++;
+                Future<T> future = completionService.submit(() -> mapper.apply(input));
+                indexesByFuture.put(future, index);
+                inFlight++;
+            });
             if (!hasMore) {
                 sourceExhausted = true;
                 return;
             }
-
-            long index = nextIndexToStart++;
-            Future<T> future = completionService.submit(() -> mapper.apply(holder.value));
-            indexesByFuture.put(future, index);
-            inFlight++;
         }
     }
 
@@ -133,9 +133,5 @@ class EagerBufferingSpliterator<T, U> implements Spliterator<T> {
     @Override
     public int characteristics() {
         return source.hasCharacteristics(Spliterator.ORDERED) ? Spliterator.ORDERED : 0;
-    }
-
-    private static final class ValueHolder<U> {
-        private U value;
     }
 }

--- a/streams/src/main/java/com/palantir/common/streams/EagerBufferingSpliterator.java
+++ b/streams/src/main/java/com/palantir/common/streams/EagerBufferingSpliterator.java
@@ -1,0 +1,141 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.streams;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.util.concurrent.Futures;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Starts more work as soon as any in-flight future completes, while returning results in source order.
+ */
+class EagerBufferingSpliterator<T, U> implements Spliterator<T> {
+    private final Spliterator<U> source;
+    private final Function<U, T> mapper;
+    private final int maxParallelism;
+    private final CompletionService<T> completionService;
+    private final IdentityHashMap<Future<T>, Long> indexesByFuture = new IdentityHashMap<>();
+    private final Map<Long, Future<T>> completedResults = new HashMap<>();
+
+    private long nextIndexToStart = 0;
+    private long nextIndexToReturn = 0;
+    private int inFlight = 0;
+    private boolean sourceExhausted = false;
+
+    EagerBufferingSpliterator(Spliterator<U> source, Function<U, T> mapper, Executor executor, int maxParallelism) {
+        checkArgument(maxParallelism > 0, "maxParallelism must be at least 1 (got %s)", maxParallelism);
+        this.source = source;
+        this.mapper = mapper;
+        this.maxParallelism = maxParallelism;
+        this.completionService = new ExecutorCompletionService<>(executor);
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super T> action) {
+        startWorkEagerly();
+
+        while (true) {
+            Future<T> result = completedResults.remove(nextIndexToReturn);
+            if (result != null) {
+                nextIndexToReturn++;
+                action.accept(Futures.getUnchecked(result));
+                return true;
+            }
+
+            Future<T> completed = completionService.poll();
+            if (completed != null) {
+                recordCompleted(completed);
+                startWorkEagerly();
+                continue;
+            }
+
+            if (inFlight == 0) {
+                return false;
+            }
+
+            recordCompleted(takeCompleted());
+            startWorkEagerly();
+        }
+    }
+
+    private void startWorkEagerly() {
+        while (!sourceExhausted && inFlight < maxParallelism) {
+            ValueHolder<U> holder = new ValueHolder<>();
+            boolean hasMore = source.tryAdvance(input -> holder.value = input);
+            if (!hasMore) {
+                sourceExhausted = true;
+                return;
+            }
+
+            long index = nextIndexToStart++;
+            Future<T> future = completionService.submit(() -> mapper.apply(holder.value));
+            indexesByFuture.put(future, index);
+            inFlight++;
+        }
+    }
+
+    private Future<T> takeCompleted() {
+        try {
+            return completionService.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void recordCompleted(Future<T> future) {
+        Long index = indexesByFuture.remove(future);
+        if (index == null) {
+            throw new SafeIllegalStateException("Received unknown future from completion service");
+        }
+        inFlight--;
+        completedResults.put(index, future);
+    }
+
+    @Override
+    public Spliterator<T> trySplit() {
+        return null;
+    }
+
+    @Override
+    public long estimateSize() {
+        long estimate = inFlight + completedResults.size() + source.estimateSize();
+        if (estimate < 0L) {
+            return Long.MAX_VALUE;
+        }
+        return estimate;
+    }
+
+    @Override
+    public int characteristics() {
+        return source.hasCharacteristics(Spliterator.ORDERED) ? Spliterator.ORDERED : 0;
+    }
+
+    private static final class ValueHolder<U> {
+        private U value;
+    }
+}

--- a/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
+++ b/streams/src/main/java/com/palantir/common/streams/MoreStreams.java
@@ -99,7 +99,10 @@ public final class MoreStreams {
      * each future to complete before returning it, but which looks ahead {@code maxParallelism} arguments to ensure a
      * fixed parallelism rate.
      *
-     * The caller is required to pass in an executor to run the mapper function on.
+     * <p>Slow elements can reduce parallelism because later work is not started until earlier results are
+     * returned.
+     *
+     * @param executor the executor to run the mapper function on
      */
     public static <U, V> Stream<V> blockingStreamWithParallelism(
             Stream<U> arguments, Function<U, V> mapper, Executor executor, int maxParallelism) {
@@ -113,6 +116,22 @@ public final class MoreStreams {
                 .onClose(arguments::close)
                 .map(MoreFutures::blockUntilCompletion)
                 .map(Futures::getUnchecked);
+    }
+
+    /**
+     * Like blockingStreamWithParallelism, but starts new work when any in-flight element completes.
+     * Results are still returned in source order.
+     *
+     * <p>Later results may be buffered until earlier elements finish.
+     *
+     * @param executor the executor to run the mapper function on
+     */
+    public static <U, V> Stream<V> eagerBlockingStreamWithParallelism(
+            Stream<U> arguments, Function<U, V> mapper, Executor executor, int maxParallelism) {
+        return StreamSupport.stream(
+                        new EagerBufferingSpliterator<>(arguments.spliterator(), mapper, executor, maxParallelism),
+                        NOT_PARALLEL)
+                .onClose(arguments::close);
     }
 
     /**

--- a/streams/src/test/java/com/palantir/common/streams/EagerBufferingSpliteratorTests.java
+++ b/streams/src/test/java/com/palantir/common/streams/EagerBufferingSpliteratorTests.java
@@ -1,0 +1,310 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.common.streams;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EagerBufferingSpliteratorTests {
+
+    private ExecutorService executorService;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+
+    @BeforeEach
+    public void before() {
+        executorService = Executors.newFixedThreadPool(10);
+        streamClosed.set(false);
+    }
+
+    @AfterEach
+    public void after() throws InterruptedException {
+        executorService.shutdown();
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testResultsReturnedInSourceOrder() {
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                IntStream.range(0, 10).boxed().onClose(() -> streamClosed.set(true)), x -> x, executorService, 3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testEmptyStream() {
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                Stream.<Integer>empty().onClose(() -> streamClosed.set(true)), x -> x, executorService, 3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).isEmpty();
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testSingleElement() {
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                Stream.of(42).onClose(() -> streamClosed.set(true)), x -> x * 2, executorService, 3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(84);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testMaxParallelismOne() {
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                IntStream.range(0, 5).boxed().onClose(() -> streamClosed.set(true)), x -> x, executorService, 1)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testImmediateFutures() {
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                IntStream.range(0, 10_000).boxed().onClose(() -> streamClosed.set(true)),
+                x -> x,
+                MoreExecutors.directExecutor(),
+                3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result)
+                .containsExactlyElementsOf(IntStream.range(0, 10_000).boxed().collect(toList()));
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testRefillsWhenOutOfOrderCompletionAlreadyAvailable() throws Exception {
+        CountDownLatch releaseElement0 = new CountDownLatch(1);
+        CountDownLatch element2Started = new CountDownLatch(1);
+        AtomicInteger executions = new AtomicInteger(0);
+        Executor executor = command -> {
+            if (executions.incrementAndGet() == 1) {
+                new Thread(command, "eager-buffering-test").start();
+            } else {
+                command.run();
+            }
+        };
+
+        CompletableFuture<List<Integer>> result = CompletableFuture.supplyAsync(
+                () -> {
+                    try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                            IntStream.range(0, 3).boxed().onClose(() -> streamClosed.set(true)),
+                            x -> {
+                                if (x == 0) {
+                                    Uninterruptibles.awaitUninterruptibly(releaseElement0);
+                                } else if (x == 2) {
+                                    element2Started.countDown();
+                                }
+                                return x;
+                            },
+                            executor,
+                            2)) {
+                        return stream.collect(toList());
+                    }
+                },
+                executorService);
+
+        try {
+            assertThat(Uninterruptibles.awaitUninterruptibly(element2Started, 2, TimeUnit.SECONDS))
+                    .as("element 2 starts before element 0 completes")
+                    .isTrue();
+        } finally {
+            releaseElement0.countDown();
+        }
+        assertThat(result.get(5, TimeUnit.SECONDS)).containsExactly(0, 1, 2);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testMaintainsParallelismWhenFirstElementIsSlow() throws InterruptedException {
+        AtomicInteger maxConcurrent = new AtomicInteger(0);
+        AtomicInteger currentConcurrent = new AtomicInteger(0);
+        CountDownLatch firstElementStarted = new CountDownLatch(1);
+
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                IntStream.range(0, 6).boxed().onClose(() -> streamClosed.set(true)),
+                x -> {
+                    int concurrent = currentConcurrent.incrementAndGet();
+                    maxConcurrent.accumulateAndGet(concurrent, Math::max);
+
+                    try {
+                        if (x == 0) {
+                            firstElementStarted.countDown();
+                            Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(200));
+                        } else {
+                            Uninterruptibles.awaitUninterruptibly(firstElementStarted);
+                            Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(50));
+                        }
+                    } finally {
+                        currentConcurrent.decrementAndGet();
+                    }
+                    return x;
+                },
+                executorService,
+                3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4, 5);
+        assertThat(maxConcurrent.get()).isEqualTo(3);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testEagerSchedulingStartsNewWorkOnCompletion() throws InterruptedException {
+        AtomicInteger elementsStarted = new AtomicInteger(0);
+        CountDownLatch element0Started = new CountDownLatch(1);
+        CountDownLatch element3Started = new CountDownLatch(1);
+
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                IntStream.range(0, 5).boxed().onClose(() -> streamClosed.set(true)),
+                x -> {
+                    elementsStarted.incrementAndGet();
+                    if (x == 0) {
+                        element0Started.countDown();
+                        boolean element3DidStart =
+                                Uninterruptibles.awaitUninterruptibly(element3Started, 2, TimeUnit.SECONDS);
+                        assertThat(element3DidStart)
+                                .as("element 3 starts before element 0 completes")
+                                .isTrue();
+                    } else if (x == 3) {
+                        element3Started.countDown();
+                    } else {
+                        Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(10));
+                    }
+                    return x;
+                },
+                executorService,
+                3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testConcurrencyRespected() throws InterruptedException {
+        AtomicInteger maxConcurrent = new AtomicInteger(0);
+        AtomicInteger currentConcurrent = new AtomicInteger(0);
+        int maxParallelism = 2;
+
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                IntStream.range(0, 10).boxed().onClose(() -> streamClosed.set(true)),
+                x -> {
+                    int concurrent = currentConcurrent.incrementAndGet();
+                    maxConcurrent.accumulateAndGet(concurrent, Math::max);
+                    try {
+                        Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(50));
+                    } finally {
+                        currentConcurrent.decrementAndGet();
+                    }
+                    return x;
+                },
+                executorService,
+                maxParallelism)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertThat(maxConcurrent.get()).isLessThanOrEqualTo(maxParallelism);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testOriginalBlockingStreamHasHeadOfLineBlocking() throws InterruptedException {
+        AtomicInteger elementsStarted = new AtomicInteger(0);
+        CountDownLatch element0Started = new CountDownLatch(1);
+        CountDownLatch element3Started = new CountDownLatch(1);
+
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.blockingStreamWithParallelism(
+                IntStream.range(0, 5).boxed().onClose(() -> streamClosed.set(true)),
+                x -> {
+                    elementsStarted.incrementAndGet();
+                    if (x == 0) {
+                        element0Started.countDown();
+                        boolean element3DidStart =
+                                Uninterruptibles.awaitUninterruptibly(element3Started, 500, TimeUnit.MILLISECONDS);
+                        assertThat(element3DidStart)
+                                .as("element 3 starts before element 0 completes")
+                                .isFalse();
+                    } else if (x == 3) {
+                        element3Started.countDown();
+                    } else {
+                        Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(10));
+                    }
+                    return x;
+                },
+                executorService,
+                3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4);
+        assertThat(streamClosed).isTrue();
+    }
+
+    @Test
+    public void testWithFlatMap() throws InterruptedException {
+        List<Integer> result;
+        try (Stream<Integer> stream = MoreStreams.eagerBlockingStreamWithParallelism(
+                Stream.of(1).flatMap(_ignored -> IntStream.range(0, 5).boxed()).onClose(() -> streamClosed.set(true)),
+                x -> x,
+                executorService,
+                3)) {
+            result = stream.collect(toList());
+        }
+
+        assertThat(result).containsExactly(0, 1, 2, 3, 4);
+        assertThat(streamClosed).isTrue();
+    }
+}


### PR DESCRIPTION
## Before this PR

`blockingStreamWithParallelism` suffers from head-of-line blocking issues.


## After this PR

Add `eagerBlockingStreamWithParallelism` which fires off work with fixed parallelism rather than maintaining a sliding window.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

